### PR TITLE
Remove spurious colon from ss.error.text.your_art_code

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -97,7 +97,7 @@
         <jms:reference-file line="13">views/Exception/error.html.twig</jms:reference-file>
         <jms:reference-file line="13">views/Exception/error404.html.twig</jms:reference-file>
         <source>ss.error.text.your_art_code</source>
-        <target>The error code is:</target>
+        <target>The error code is</target>
       </trans-unit>
       <trans-unit id="ad9824f6caa954891a11b7db631468f24b9194ac" resname="ss.error.title">
         <jms:reference-file line="3">views/Exception/error.html.twig</jms:reference-file>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -97,7 +97,7 @@
         <jms:reference-file line="13">views/Exception/error.html.twig</jms:reference-file>
         <jms:reference-file line="13">views/Exception/error404.html.twig</jms:reference-file>
         <source>ss.error.text.your_art_code</source>
-        <target>De fout code is:</target>
+        <target>De fout code is</target>
       </trans-unit>
       <trans-unit id="ad9824f6caa954891a11b7db631468f24b9194ac" resname="ss.error.title">
         <jms:reference-file line="3">views/Exception/error.html.twig</jms:reference-file>


### PR DESCRIPTION
Because the colon is already part of the template, it should not be in the translations:

https://github.com/SURFnet/Stepup-SelfService/blob/81ae4c8b03f03259ff5ca2482f49a2eef1c95060/app/Resources/SurfnetStepupBundle/views/Exception/error404.html.twig#L13
https://github.com/SURFnet/Stepup-SelfService/blob/81ae4c8b03f03259ff5ca2482f49a2eef1c95060/app/Resources/SurfnetStepupBundle/views/Exception/error.html.twig#L13