### PR TITLE
Clear:left after every third column of the second factor selection list

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
@@ -19,13 +19,22 @@
     }
 }
 
-.second-factor-selector {
-    text-align: center;
+.second-factors {
 
-    img {
-        margin-top: 1em;
-        max-width: 200px;
-        max-height: 90px;
+    @media (min-width: 992px) {
+        > div:nth-child(3n+4) {
+            clear: left;
+        }
+    }
+
+    .second-factor-selector {
+        text-align: center;
+
+        img {
+            margin-top: 1em;
+            max-width: 200px;
+            max-height: 90px;
+        }
     }
 }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
@@ -21,7 +21,7 @@
 
 .second-factors {
 
-    @media (min-width: 992px) {
+    @media (min-width: @screen-md) {
         > div:nth-child(3n+4) {
             clear: left;
         }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/displaySecondFactorTypes.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/displaySecondFactorTypes.html.twig
@@ -11,7 +11,7 @@
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-    <div class="row">
+    <div class="row second-factors">
         {% if availableSecondFactors.sms is defined %}
             {% include 'SurfnetStepupSelfServiceSelfServiceBundle::Registration/partial/secondFactor.html.twig' with {
                 'type': 'sms',


### PR DESCRIPTION
Tested in Firefox and Chrome on Linux. On different view port widths.

This pull request fixes the problem when the list of second factors is not ordered in rows from left to right. The second row would start underneath the last item of the first row.

This is a common Bootstrap issue. Bootstrap dictates a row element for each row of columns. This is not always an option. And in that case a css workaround can be used to fix the styling issue.