### PR TITLE
Support of multiple second factors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /web/bundles/
 /web/app_dev.php
 /web/app_dev.php.dist
+/web/js
+/web/css
 /app/bootstrap.php.cache
 /app/cache/*
 /app/config/parameters.yml

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-05-30T16:11:35Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T16:16:53Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -462,12 +462,27 @@ For all devices with a USB port.</target>
         <target>Link your YubiKey</target>
       </trans-unit>
       <trans-unit id="c954ee253d560c6f6d5baf1811ca34988a9029d8" resname="ss.second_factor.list.button.register_second_factor">
-        <jms:reference-file line="13">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="29">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor.list.button.register_second_factor</source>
         <target>Register token</target>
       </trans-unit>
+      <trans-unit id="5a6f59c486a9cc18c46c9147eb55a76424815f62" resname="ss.second_factor.list.max_number_of_tokens_reached_text">
+        <jms:reference-file line="11">views/SecondFactor/list.html.twig</jms:reference-file>
+        <source>ss.second_factor.list.max_number_of_tokens_reached_text</source>
+        <target>The maximum number of token registrations has been reached.</target>
+      </trans-unit>
+      <trans-unit id="b78987cb5a9d442fe9272812a1ea5cf8afc39523" resname="ss.second_factor.list.max_number_of_tokens_text">
+        <jms:reference-file line="9">views/SecondFactor/list.html.twig</jms:reference-file>
+        <source>ss.second_factor.list.max_number_of_tokens_text</source>
+        <target>This is an overview of your registered tokens. You can register a maximum of %max_number% tokens.</target>
+      </trans-unit>
+      <trans-unit id="efa2d0485dc634ae0f039634541529dce393e36c" resname="ss.second_factor.list.text.add_second_factor">
+        <jms:reference-file line="25">views/SecondFactor/list.html.twig</jms:reference-file>
+        <source>ss.second_factor.list.text.add_second_factor</source>
+        <target state="new">Add new token</target>
+      </trans-unit>
       <trans-unit id="474737f264f9527e93a9f4f4c4c380331b52e759" resname="ss.second_factor.list.text.no_second_factors">
-        <jms:reference-file line="10">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="23">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor.list.text.no_second_factors</source>
         <target>There are no tokens registered for your account. Click on 'Register token' to register a new token.
 </target>
@@ -475,20 +490,20 @@ For all devices with a USB port.</target>
       <trans-unit id="a1a1aa0e1c0a720bc6144c5a5a03d89ad6fdcc87" resname="ss.second_factor.list.text.unverified">
         <jms:reference-file line="34">Resources/views/translations.twig</jms:reference-file>
         <source>ss.second_factor.list.text.unverified</source>
-        <target>For the token below the e-mail address must be verified. An e-mail was sent to '%email%'. Please follow the instructions in this e-mail to continue with the registration. Didn't receive an e-mail? Remove the token to try again.
+        <target>For the token(s) below the e-mail address must be verified. An e-mail was sent to '%email%'. Please follow the instructions in this e-mail to continue with the registration. Didn't receive an e-mail? Remove the token to try again.
 </target>
       </trans-unit>
       <trans-unit id="da0c3086f8d5dc181e074f24d12e8ccc27429dcf" resname="ss.second_factor.list.text.verified">
         <jms:reference-file line="33">Resources/views/translations.twig</jms:reference-file>
         <source>ss.second_factor.list.text.verified</source>
-        <target>The following token is registered for your account, but not yet activated.
+        <target>The following tokens are registered for your account, but not yet activated.
 
 An e-mail with your activation code has been sent to the e-mail address %email%. Please follow the instructions in the e-mail on how to proceed.</target>
       </trans-unit>
       <trans-unit id="15bc6a0b6f49cc0b44bd30ed7290e347e1267117" resname="ss.second_factor.list.text.vetted">
         <jms:reference-file line="32">Resources/views/translations.twig</jms:reference-file>
         <source>ss.second_factor.list.text.vetted</source>
-        <target>The following token is registered for your account.</target>
+        <target>The following tokens are registered for your account.</target>
       </trans-unit>
       <trans-unit id="59ae5f416e832eeec457e8f73d11d196bcf9c6e5" resname="ss.second_factor.list.title">
         <jms:reference-file line="4">views/SecondFactor/list.html.twig</jms:reference-file>
@@ -506,12 +521,12 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
         <target>Your token has been removed.</target>
       </trans-unit>
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
-        <jms:reference-file line="50">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="62">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor.revoke.button.revoke</source>
         <target>Remove</target>
       </trans-unit>
       <trans-unit id="17d18b6bcd8642fedf8e5371cb722efc604e8281" resname="ss.second_factor.revoke.button.test">
-        <jms:reference-file line="46">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="58">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor.revoke.button.test</source>
         <target>Test</target>
       </trans-unit>
@@ -586,12 +601,12 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
         <target>YubiKey</target>
       </trans-unit>
       <trans-unit id="fedd12f3e661692730a3650ef6db64e71c9d8441" resname="ss.second_factor_list.header.second_factor_identifier">
-        <jms:reference-file line="32">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="44">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor_list.header.second_factor_identifier</source>
         <target>ID</target>
       </trans-unit>
       <trans-unit id="e4d199fd46ed7fa1c78a8fde6faef80f034cd662" resname="ss.second_factor_list.header.type">
-        <jms:reference-file line="31">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="43">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor_list.header.type</source>
         <target>Token</target>
       </trans-unit>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-05-30T16:11:31Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T16:16:48Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -462,31 +462,46 @@ Geschikt voor alle devices met een USB-poort.</target>
         <target>Koppel je YubiKey</target>
       </trans-unit>
       <trans-unit id="c954ee253d560c6f6d5baf1811ca34988a9029d8" resname="ss.second_factor.list.button.register_second_factor">
-        <jms:reference-file line="13">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="29">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor.list.button.register_second_factor</source>
         <target>Registreer token</target>
       </trans-unit>
+      <trans-unit id="5a6f59c486a9cc18c46c9147eb55a76424815f62" resname="ss.second_factor.list.max_number_of_tokens_reached_text">
+        <jms:reference-file line="11">views/SecondFactor/list.html.twig</jms:reference-file>
+        <source>ss.second_factor.list.max_number_of_tokens_reached_text</source>
+        <target state="new">Het is niet meer mogelijk om nieuwe tokens te registreren.</target>
+      </trans-unit>
+      <trans-unit id="b78987cb5a9d442fe9272812a1ea5cf8afc39523" resname="ss.second_factor.list.max_number_of_tokens_text">
+        <jms:reference-file line="9">views/SecondFactor/list.html.twig</jms:reference-file>
+        <source>ss.second_factor.list.max_number_of_tokens_text</source>
+        <target>Hieronder vind je een overzicht van je geregistreerde tokens. Je mag %max_number% tokens registreren.</target>
+      </trans-unit>
+      <trans-unit id="efa2d0485dc634ae0f039634541529dce393e36c" resname="ss.second_factor.list.text.add_second_factor">
+        <jms:reference-file line="25">views/SecondFactor/list.html.twig</jms:reference-file>
+        <source>ss.second_factor.list.text.add_second_factor</source>
+        <target state="new">Registreer nieuw token</target>
+      </trans-unit>
       <trans-unit id="474737f264f9527e93a9f4f4c4c380331b52e759" resname="ss.second_factor.list.text.no_second_factors">
-        <jms:reference-file line="10">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="23">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor.list.text.no_second_factors</source>
         <target>Er zijn geen tokens geregistreerd voor jouw account. Klik op 'Registreer token' om een nieuw token te registreren.</target>
       </trans-unit>
       <trans-unit id="a1a1aa0e1c0a720bc6144c5a5a03d89ad6fdcc87" resname="ss.second_factor.list.text.unverified">
         <jms:reference-file line="34">Resources/views/translations.twig</jms:reference-file>
         <source>ss.second_factor.list.text.unverified</source>
-        <target>Voor het onderstaande token moet het e-mailadres nog bevestigd worden. Er is een e-mail verstuurd naar '%email%'. Volg de instructies in deze e-mail om verder te gaan met de registratie. Geen e-mail ontvangen? Verwijder het token om het opnieuw te proberen.</target>
+        <target>Voor de onderstaande token(s) moet het e-mailadres nog bevestigd worden. Er is een e-mail verstuurd naar '%email%'. Volg de instructies in deze e-mail om verder te gaan met de registratie. Geen e-mail ontvangen? Verwijder het token om het opnieuw te proberen.</target>
       </trans-unit>
       <trans-unit id="da0c3086f8d5dc181e074f24d12e8ccc27429dcf" resname="ss.second_factor.list.text.verified">
         <jms:reference-file line="33">Resources/views/translations.twig</jms:reference-file>
         <source>ss.second_factor.list.text.verified</source>
-        <target>Het volgende token is geregistreerd voor jouw account, maar nog niet geactiveerd.
+        <target>De volgende token(s) zijn geregistreerd voor jouw account, maar nog niet geactiveerd.
 
 Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg de instructies uit de e-mail om je token te activeren.</target>
       </trans-unit>
       <trans-unit id="15bc6a0b6f49cc0b44bd30ed7290e347e1267117" resname="ss.second_factor.list.text.vetted">
         <jms:reference-file line="32">Resources/views/translations.twig</jms:reference-file>
         <source>ss.second_factor.list.text.vetted</source>
-        <target>Het volgende token is geregistreerd voor jouw account.</target>
+        <target>De volgende token(s) zijn geregistreerd voor jouw account.</target>
       </trans-unit>
       <trans-unit id="59ae5f416e832eeec457e8f73d11d196bcf9c6e5" resname="ss.second_factor.list.title">
         <jms:reference-file line="4">views/SecondFactor/list.html.twig</jms:reference-file>
@@ -504,12 +519,12 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
         <target>Je token is verwijderd.</target>
       </trans-unit>
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
-        <jms:reference-file line="50">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="62">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor.revoke.button.revoke</source>
         <target>Verwijderen</target>
       </trans-unit>
       <trans-unit id="17d18b6bcd8642fedf8e5371cb722efc604e8281" resname="ss.second_factor.revoke.button.test">
-        <jms:reference-file line="46">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="58">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor.revoke.button.test</source>
         <target>Testen</target>
       </trans-unit>
@@ -584,12 +599,12 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
         <target>YubiKey</target>
       </trans-unit>
       <trans-unit id="fedd12f3e661692730a3650ef6db64e71c9d8441" resname="ss.second_factor_list.header.second_factor_identifier">
-        <jms:reference-file line="32">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="44">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor_list.header.second_factor_identifier</source>
         <target>ID</target>
       </trans-unit>
       <trans-unit id="e4d199fd46ed7fa1c78a8fde6faef80f034cd662" resname="ss.second_factor_list.header.type">
-        <jms:reference-file line="31">views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="43">views/SecondFactor/list.html.twig</jms:reference-file>
         <source>ss.second_factor_list.header.type</source>
         <target>Token</target>
       </trans-unit>

--- a/app/Resources/translations/validators.en_GB.xliff
+++ b/app/Resources/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-05-30T16:11:35Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T16:16:53Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/validators.nl_NL.xliff
+++ b/app/Resources/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-05-30T16:11:31Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2017-11-07T16:16:48Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -161,6 +161,7 @@ jms_translation:
             extractors: []
 
 surfnet_stepup_self_service_self_service:
+    max_number_of_tokens: %number_of_tokens_per_identity%
     enabled_second_factors: %enabled_second_factors%
     enabled_generic_second_factors: %enabled_generic_second_factors%
     second_factor_test_identity_provider:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -61,3 +61,6 @@ parameters:
 
     session_max_absolute_lifetime: 3600 # 1 hours * 60 minutes * 60 seconds
     session_max_relative_lifetime: 600  # 10 minutes * 60 seconds
+
+    # The maximum number of tokens each identity (person) can register.
+    number_of_tokens_per_identity: 2

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
@@ -19,9 +19,7 @@
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Surfnet\StepupSelfService\SamlStepupProviderBundle\Provider\ViewConfig;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SecondFactorService;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -41,40 +39,38 @@ class RegistrationController extends Controller
         /** @var SecondFactorService $service */
         $service = $this->get('surfnet_stepup_self_service_self_service.service.second_factor');
 
-        $availableSecondFactors = $this->getParameter('ss.enabled_second_factors');
-        if (!empty($institutionConfigurationOptions->allowedSecondFactors)) {
-            $availableSecondFactors = array_intersect(
-                $availableSecondFactors,
-                $institutionConfigurationOptions->allowedSecondFactors
-            );
-        }
-        $availableSecondFactors = array_combine($availableSecondFactors, $availableSecondFactors);
-        $availableGsspSecondFactors = [];
+        // Get all available second factors from the config.
+        $allSecondFactors = $this->getParameter('ss.enabled_second_factors');
 
-        foreach ($availableSecondFactors as $index => $secondFactor) {
-            try {
+        $secondFactors = $service->getSecondFactorsForIdentity(
+            $identity,
+            $allSecondFactors,
+            $institutionConfigurationOptions->allowedSecondFactors,
+            $this->getParameter('self_service.second_factor.max_tokens_per_identity')
+        );
+
+        if ($secondFactors->getRegistrationsLeft() <= 0) {
+            $this->get('logger')->notice(
+                'User tried to register a new token but maximum number of tokens is reached. Redirecting to overview'
+            );
+            return $this->forward('SurfnetStepupSelfServiceSelfServiceBundle:SecondFactor:list');
+        }
+
+
+        $availableGsspSecondFactors = [];
+        foreach ($secondFactors->available as $index => $secondFactor) {
+            if ($this->has("gssp.view_config.{$secondFactor}")) {
                 /** @var ViewConfig $secondFactorConfig */
                 $secondFactorConfig = $this->get("gssp.view_config.{$secondFactor}");
                 $availableGsspSecondFactors[$index] = $secondFactorConfig;
                 // Remove the gssp second factors from the regular second factors.
-                unset($availableSecondFactors[$index]);
-            } catch (ServiceNotFoundException $e) {
-                continue;
+                unset($secondFactors->available[$index]);
             }
         }
 
-
-        // Get all available second factors from the config.
-        $allSecondFactors = $this->getParameter('ss.enabled_second_factors');
-        $unverified = $service->findUnverifiedByIdentity($identity->id);
-        $verified = $service->findVerifiedByIdentity($identity->id);
-        $vetted = $service->findVettedByIdentity($identity->id);
-        // Determine which Second Factors are still available for registration.
-        $available = $service->determineAvailable($allSecondFactors, $unverified, $verified, $vetted);
-
         return [
             'commonName' => $this->getIdentity()->commonName,
-            'availableSecondFactors' => array_combine($available, $available),
+            'availableSecondFactors' => $secondFactors->available,
             'availableGsspSecondFactors' => $availableGsspSecondFactors,
             'tiqrAppAndroidUrl' => $this->getParameter('tiqr_app_android_url'),
             'tiqrAppIosUrl'     => $this->getParameter('tiqr_app_ios_url'),

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
@@ -44,15 +44,18 @@ class SecondFactorController extends Controller
         $secondFactors = $service->getSecondFactorsForIdentity(
             $identity,
             $allSecondFactors,
-            $institutionConfigurationOptions->allowedSecondFactors
+            $institutionConfigurationOptions->allowedSecondFactors,
+            $this->getParameter('self_service.second_factor.max_tokens_per_identity')
         );
 
         return [
             'email' => $identity->email,
-            'unverifiedSecondFactors' => $secondFactors['unverified'],
-            'verifiedSecondFactors' => $verified,
-            'vettedSecondFactors' => $vetted,
-            'availableSecondFactors' => $available,
+            'maxNumberOfTokens' => $secondFactors->getMaximumNumberOfRegistrations(),
+            'registrationsLeft' => $secondFactors->getRegistrationsLeft(),
+            'unverifiedSecondFactors' => $secondFactors->unverified,
+            'verifiedSecondFactors' => $secondFactors->verified,
+            'vettedSecondFactors' => $secondFactors->vetted,
+            'availableSecondFactors' => $secondFactors->available,
         ];
     }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
@@ -34,21 +34,22 @@ class SecondFactorController extends Controller
     public function listAction()
     {
         $identity = $this->getIdentity();
-
+        $institutionConfigurationOptions = $this->get('self_service.service.institution_configuration_options')
+            ->getInstitutionConfigurationOptionsFor($this->getIdentity()->institution);
         /** @var SecondFactorService $service */
         $service = $this->get('surfnet_stepup_self_service_self_service.service.second_factor');
-
         // Get all available second factors from the config.
         $allSecondFactors = $this->getParameter('ss.enabled_second_factors');
-        $unverified = $service->findUnverifiedByIdentity($identity->id);
-        $verified = $service->findVerifiedByIdentity($identity->id);
-        $vetted = $service->findVettedByIdentity($identity->id);
-        // Determine which Second Factors are still available for registration.
-        $available = $service->determineAvailable($allSecondFactors, $unverified, $verified, $vetted);
+
+        $secondFactors = $service->getSecondFactorsForIdentity(
+            $identity,
+            $allSecondFactors,
+            $institutionConfigurationOptions->allowedSecondFactors
+        );
 
         return [
             'email' => $identity->email,
-            'unverifiedSecondFactors' => $unverified,
+            'unverifiedSecondFactors' => $secondFactors['unverified'],
             'verifiedSecondFactors' => $verified,
             'vettedSecondFactors' => $vetted,
             'availableSecondFactors' => $available,

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
@@ -38,11 +38,20 @@ class SecondFactorController extends Controller
         /** @var SecondFactorService $service */
         $service = $this->get('surfnet_stepup_self_service_self_service.service.second_factor');
 
+        // Get all available second factors from the config.
+        $allSecondFactors = $this->getParameter('ss.enabled_second_factors');
+        $unverified = $service->findUnverifiedByIdentity($identity->id);
+        $verified = $service->findVerifiedByIdentity($identity->id);
+        $vetted = $service->findVettedByIdentity($identity->id);
+        // Determine which Second Factors are still available for registration.
+        $available = $service->determineAvailable($allSecondFactors, $unverified, $verified, $vetted);
+
         return [
             'email' => $identity->email,
-            'unverifiedSecondFactors' => $service->findUnverifiedByIdentity($identity->id),
-            'verifiedSecondFactors' => $service->findVerifiedByIdentity($identity->id),
-            'vettedSecondFactors' => $service->findVettedByIdentity($identity->id),
+            'unverifiedSecondFactors' => $unverified,
+            'verifiedSecondFactors' => $verified,
+            'vettedSecondFactors' => $vetted,
+            'availableSecondFactors' => $available,
         ];
     }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/DependencyInjection/Configuration.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/DependencyInjection/Configuration.php
@@ -34,6 +34,9 @@ class Configuration implements ConfigurationInterface
         $this->appendSecondFactorTestIdentityProvider($childNodes);
         $this->appendSessionConfiguration($childNodes);
 
+        $childNodes->integerNode('max_number_of_tokens')
+            ->isRequired();
+
         return $treeBuilder;
     }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/DependencyInjection/SurfnetStepupSelfServiceSelfServiceExtension.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/DependencyInjection/SurfnetStepupSelfServiceSelfServiceExtension.php
@@ -63,6 +63,10 @@ class SurfnetStepupSelfServiceSelfServiceExtension extends Extension
             'self_service.security.authentication.session.maximum_relative_lifetime_in_seconds',
             $config['session_lifetimes']['max_relative_lifetime']
         );
+        $container->setParameter(
+            'self_service.second_factor.max_tokens_per_identity',
+            $config['max_number_of_tokens']
+        );
 
         $this->parseSecondFactorTestIdentityProviderConfiguration(
             $config['second_factor_test_identity_provider'],

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -7,7 +7,11 @@
     <h2>{{ block('page_title') }}</h2>
 
     {% if (unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty) or availableSecondFacotrs.elements is not empty %}
-        <p>{{ 'ss.second_factor.list.text.no_second_factors'|trans }}</p>
+        {% if availableSecondFacotrs.elements|length > 0  %}
+            <p>{{ 'ss.second_factor.list.text.add_second_factor'|trans }}</p>
+        {% else %}
+            <p>{{ 'ss.second_factor.list.text.no_second_factors'|trans }}</p>
+        {% endif %}
         <a href="{{ path('ss_registration_display_types') }}"
            class="btn btn-primary">
             {{ 'ss.second_factor.list.button.register_second_factor'|trans }}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -5,21 +5,29 @@
 
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
+    {% if registrationsLeft > 0 %}
+        <p>{{ 'ss.second_factor.list.max_number_of_tokens_text'|trans({'%max_number%': maxNumberOfTokens}) }}</p>
+    {% else %}
+        <p>{{ 'ss.second_factor.list.max_number_of_tokens_reached_text'|trans({'%max_number%': maxNumberOfTokens}) }}</p>
+    {% endif %}
 
-    {% if (unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty) or availableSecondFacotrs.elements is not empty %}
-        {% if availableSecondFacotrs.elements|length > 0  %}
-            <p>{{ 'ss.second_factor.list.text.add_second_factor'|trans }}</p>
-        {% else %}
+    {{ macro.secondFactorTable(vettedSecondFactors, 'ss.second_factor.list.text.vetted', 'vetted', email) }}
+    {{ macro.secondFactorTable(verifiedSecondFactors, 'ss.second_factor.list.text.verified', 'verified', email) }}
+    {{ macro.secondFactorTable(unverifiedSecondFactors, 'ss.second_factor.list.text.unverified', 'unverified', email) }}
+
+    {% if registrationsLeft > 0
+            and ((unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty)
+            or availableSecondFactors is not empty)
+    %}
+        {% if (unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty) %}
             <p>{{ 'ss.second_factor.list.text.no_second_factors'|trans }}</p>
+        {% else %}
+            <p>{{ 'ss.second_factor.list.text.add_second_factor'|trans }}</p>
         {% endif %}
         <a href="{{ path('ss_registration_display_types') }}"
            class="btn btn-primary">
             {{ 'ss.second_factor.list.button.register_second_factor'|trans }}
         </a>
-    {% else %}
-        {{ macro.secondFactorTable(vettedSecondFactors, 'ss.second_factor.list.text.vetted', 'vetted', email) }}
-        {{ macro.secondFactorTable(verifiedSecondFactors, 'ss.second_factor.list.text.verified', 'verified', email) }}
-        {{ macro.secondFactorTable(unverifiedSecondFactors, 'ss.second_factor.list.text.unverified', 'unverified', email) }}
     {% endif %}
 
 {% endblock %}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -6,7 +6,7 @@
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-    {% if unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty %}
+    {% if (unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty) or availableSecondFacotrs.elements is not empty %}
         <p>{{ 'ss.second_factor.list.text.no_second_factors'|trans }}</p>
         <a href="{{ path('ss_registration_display_types') }}"
            class="btn btn-primary">

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -301,7 +301,7 @@ class SecondFactorService
     {
         foreach ($collection->getElements() as $secondFactor) {
             $keyFound = array_search($secondFactor->type, $allSecondFactors);
-            if ($keyFound) {
+            if (is_numeric($keyFound)) {
                 unset($allSecondFactors[$keyFound]);
             }
         }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -307,4 +307,33 @@ class SecondFactorService
         }
         return $allSecondFactors;
     }
+
+    /**
+     * @param $identity
+     * @param $allSecondFactors
+     * @param $allowedSecondFactors
+     * @return array
+     */
+    public function getSecondFactorsForIdentity($identity, $allSecondFactors, $allowedSecondFactors)
+    {
+        $unverified = $this->findUnverifiedByIdentity($identity->id);
+        $verified = $this->findVerifiedByIdentity($identity->id);
+        $vetted = $this->findVettedByIdentity($identity->id);
+        // Determine which Second Factors are still available for registration.
+        $available = $this->determineAvailable($allSecondFactors, $unverified, $verified, $vetted);
+
+        if (!empty($allowedSecondFactors)) {
+            $available = array_intersect(
+                $available,
+                $allowedSecondFactors
+            );
+        }
+
+        return [
+            'unverified' => $unverified,
+            'verified' => $verified,
+            'vetted' => $vetted,
+            'available' => $available,
+        ];
+    }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Service;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\UnverifiedSecondFactorSearchQuery;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\VerifiedSecondFactorSearchQuery;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\VettedSecondFactorSearchQuery;
+use Surfnet\StepupMiddlewareClientBundle\Dto\CollectionDto;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Command\RevokeOwnSecondFactorCommand;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Command\VerifyEmailCommand;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\UnverifiedSecondFactor;
@@ -270,5 +271,40 @@ class SecondFactorService
             default:
                 throw new LogicException('Searching by second factor ID cannot result in multiple results.');
         }
+    }
+
+    /**
+     * @param array $allSecondFactors
+     * @param UnverifiedSecondFactorCollection $unverifiedCollection
+     * @param VerifiedSecondFactorCollection $verifiedCollection
+     * @param VettedSecondFactorCollection $vettedCollection
+     * @return array
+     */
+    public function determineAvailable(
+        array $allSecondFactors,
+        UnverifiedSecondFactorCollection $unverifiedCollection,
+        VerifiedSecondFactorCollection $verifiedCollection,
+        VettedSecondFactorCollection $vettedCollection
+    ) {
+        $allSecondFactors = $this->filterAvailableSecondFactors($allSecondFactors, $unverifiedCollection);
+        $allSecondFactors = $this->filterAvailableSecondFactors($allSecondFactors, $verifiedCollection);
+        $allSecondFactors = $this->filterAvailableSecondFactors($allSecondFactors, $vettedCollection);
+        return $allSecondFactors;
+    }
+
+    /**
+     * @param array $allSecondFactors
+     * @param CollectionDto $collection
+     * @return array
+     */
+    private function filterAvailableSecondFactors(array $allSecondFactors, CollectionDto $collection)
+    {
+        foreach ($collection as $secondFactor) {
+            $keyFound = array_search($secondFactor->type, $allSecondFactors);
+            if ($keyFound) {
+                unset($allSecondFactors[$keyFound]);
+            }
+        }
+        return $allSecondFactors;
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -280,7 +280,7 @@ class SecondFactorService
      * @param VettedSecondFactorCollection $vettedCollection
      * @return array
      */
-    public function determineAvailable(
+    private function determineAvailable(
         array $allSecondFactors,
         UnverifiedSecondFactorCollection $unverifiedCollection,
         VerifiedSecondFactorCollection $verifiedCollection,
@@ -299,7 +299,7 @@ class SecondFactorService
      */
     private function filterAvailableSecondFactors(array $allSecondFactors, CollectionDto $collection)
     {
-        foreach ($collection as $secondFactor) {
+        foreach ($collection->getElements() as $secondFactor) {
             $keyFound = array_search($secondFactor->type, $allSecondFactors);
             if ($keyFound) {
                 unset($allSecondFactors[$keyFound]);
@@ -312,10 +312,15 @@ class SecondFactorService
      * @param $identity
      * @param $allSecondFactors
      * @param $allowedSecondFactors
-     * @return array
+     * @param $maximumNumberOfRegistrations
+     * @return SecondFactorTypeCollection
      */
-    public function getSecondFactorsForIdentity($identity, $allSecondFactors, $allowedSecondFactors)
-    {
+    public function getSecondFactorsForIdentity(
+        $identity,
+        $allSecondFactors,
+        $allowedSecondFactors,
+        $maximumNumberOfRegistrations
+    ) {
         $unverified = $this->findUnverifiedByIdentity($identity->id);
         $verified = $this->findVerifiedByIdentity($identity->id);
         $vetted = $this->findVettedByIdentity($identity->id);
@@ -329,11 +334,13 @@ class SecondFactorService
             );
         }
 
-        return [
-            'unverified' => $unverified,
-            'verified' => $verified,
-            'vetted' => $vetted,
-            'available' => $available,
-        ];
+        $collection = new SecondFactorTypeCollection();
+        $collection->unverified = $unverified;
+        $collection->verified   = $verified;
+        $collection->vetted     = $vetted;
+        $collection->available  = array_combine($available, $available);
+        $collection->maxNumberOfRegistrations = $maximumNumberOfRegistrations;
+
+        return $collection;
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorTypeCollection.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorTypeCollection.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Service;
+
+
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\UnverifiedSecondFactorCollection;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\VerifiedSecondFactorCollection;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\VettedSecondFactorCollection;
+
+class SecondFactorTypeCollection
+{
+    /**
+     * @var int
+     */
+    public $maxNumberOfRegistrations;
+
+    /**
+     * @var UnverifiedSecondFactorCollection
+     */
+    public $unverified;
+
+    /**
+     * @var VerifiedSecondFactorCollection
+     */
+    public $verified;
+
+    /**
+     * @var VettedSecondFactorCollection
+     */
+    public $vetted;
+
+    /**
+     * @var array
+     */
+    public $available;
+
+    /**
+     * @return int
+     */
+    public function getMaximumNumberOfRegistrations()
+    {
+        return $this->maxNumberOfRegistrations;
+    }
+
+    public function getRegistrationsLeft()
+    {
+        $total = $this->maxNumberOfRegistrations;
+
+        $total -= $this->unverified->getTotalItems();
+        $total -= $this->verified->getTotalItems();
+        $total -= $this->vetted->getTotalItems();
+
+        return $total;
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/SecondFactorTypeCollectionTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/SecondFactorTypeCollectionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Tests\Service;
+
+use PHPUnit_Framework_TestCase as UnitTest;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\UnverifiedSecondFactorCollection;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\VerifiedSecondFactorCollection;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\VettedSecondFactorCollection;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SecondFactorTypeCollection;
+use Mockery as m;
+
+class SecondFactorTypeCollectionTest extends UnitTest
+{
+    public function test_it_calculates_number_of_registrations_left()
+    {
+        $collection = new SecondFactorTypeCollection();
+
+        $unverified = m::mock(UnverifiedSecondFactorCollection::class);
+        $unverified
+            ->shouldReceive('getTotalItems')
+            ->once()
+            ->andReturn(1);
+
+        $verified = m::mock(VerifiedSecondFactorCollection::class);
+        $verified
+            ->shouldReceive('getTotalItems')
+            ->once()
+            ->andReturn(1);
+
+        $vetted = m::mock(VettedSecondFactorCollection::class);
+        $vetted
+            ->shouldReceive('getTotalItems')
+            ->once()
+            ->andReturn(1);
+
+        $available = [
+            'yubikey',
+            'sms',
+            'tiqr',
+        ];
+
+        $collection->unverified = $unverified;
+        $collection->verified = $verified;
+        $collection->vetted = $vetted;
+        $collection->available = $available;
+        $collection->maxNumberOfRegistrations = 4;
+
+        $this->assertEquals(1, $collection->getRegistrationsLeft());
+        $this->assertEquals(4, $collection->getMaximumNumberOfRegistrations());
+    }
+}


### PR DESCRIPTION
**Review notes**
A user can now register multiple SF tokens. The total amount can be set as a config parameter.

**Tasks**
 - [x] Travis build is passing
 - [x] Updated documentation
 - [x] Updated pivotal tracker
 - [x] Wrote appropriate tests
 - [x] Updated documentation

This PR is part of a series of changes in [SS](https://github.com/OpenConext/Stepup-SelfService/pull/127), [MW](https://github.com/OpenConext/Stepup-Middleware/pull/199) and [GW](https://github.com/OpenConext/Stepup-Gateway/pull/123).

For more information about the changes see [Pivotal](https://www.pivotaltracker.com/story/show/144697285) and the updated [docs](https://github.com/OpenConext/Stepup-Deploy/wiki/API-Design).