### PR TITLE
Add 'print' and 'pdf' buttons on registration confirm page

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-22T13:14:28Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-01-22T13:59:08Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -265,17 +265,32 @@
       <trans-unit id="63974b83ce6262c68656a606d22f6538742e22c5" resname="ss.registration.registration_email_sent.text.no_ra_locations_for_your_institution">
         <source>ss.registration.registration_email_sent.text.no_ra_locations_for_your_institution</source>
         <target>There are no locations available within your institution to activate your token. Please contact your helpdesk for support.</target>
-        <jms:reference-file line="58">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+        <jms:reference-file line="75">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8388ff05103a22d0917788a48ccdc9716a353ac8" resname="ss.registration.registration_email_sent.text.no_ras_for_your_institution">
         <source>ss.registration.registration_email_sent.text.no_ras_for_your_institution</source>
         <target>There are no locations available within your institution to activate your token. Please contact your helpdesk for support.</target>
-        <jms:reference-file line="76">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+        <jms:reference-file line="93">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c9ea58235246dd0f14a2d6aaed379ad0638d0e7" resname="ss.registration.registration_email_sent.text.registration_code_has_been_sent">
         <source>ss.registration.registration_email_sent.text.registration_code_has_been_sent</source>
         <target>An e-mail containing these instructions and your activation code has also been sent to the e-mail address %email%.</target>
         <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="9cd651eed31a40300b9bdbe4eb6f43b47590ab13" resname="ss.registration.registration_email_sent.text.registration_code_has_been_sent_no_email">
+        <source>ss.registration.registration_email_sent.text.registration_code_has_been_sent_no_email</source>
+        <target>If you do not have access (yet) to your e-mail address you can also print or download the instructions and your activation code.</target>
+        <jms:reference-file line="54">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="4cf581fa68d2c12db4d799554971856cbecc3e16" resname="ss.registration.registration_email_sent.text.registration_code_has_been_sent_pdf">
+        <source>ss.registration.registration_email_sent.text.registration_code_has_been_sent_pdf</source>
+        <target>PDF</target>
+        <jms:reference-file line="65">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="da18b75fb1c21ae87ec2ec68d747518bd2f3659f" resname="ss.registration.registration_email_sent.text.registration_code_has_been_sent_print">
+        <source>ss.registration.registration_email_sent.text.registration_code_has_been_sent_print</source>
+        <target>Print</target>
+        <jms:reference-file line="61">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ef48b4bbb1cef4ef12eb3e5146beb743e648752" resname="ss.registration.registration_email_sent.text.thank_you_for_registration">
         <source>ss.registration.registration_email_sent.text.thank_you_for_registration</source>
@@ -290,12 +305,12 @@
       <trans-unit id="536255f00c5e95be847f318b9a692596a9d927a2" resname="ss.registration.registration_email_sent.title.list_of_ra_locations">
         <source>ss.registration.registration_email_sent.title.list_of_ra_locations</source>
         <target>Location(s) to activate your token</target>
-        <jms:reference-file line="55">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+        <jms:reference-file line="72">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fad1d50cfe9eadd2b8c3dd3e10456e70a5c927f0" resname="ss.registration.registration_email_sent.title.list_of_ras">
         <source>ss.registration.registration_email_sent.title.list_of_ras</source>
         <target>Location(s) to activate your token</target>
-        <jms:reference-file line="73">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+        <jms:reference-file line="90">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6348b54419006fd2ee31e33581af254358acd8e8" resname="ss.registration.selector.sms.alt">
         <source>ss.registration.selector.sms.alt</source>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-22T13:14:23Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-01-22T13:59:02Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -265,17 +265,32 @@
       <trans-unit id="63974b83ce6262c68656a606d22f6538742e22c5" resname="ss.registration.registration_email_sent.text.no_ra_locations_for_your_institution">
         <source>ss.registration.registration_email_sent.text.no_ra_locations_for_your_institution</source>
         <target>Er zijn geen locaties beschikbaar binnen je instelling om je token te activeren. Neem contact op met je helpdesk voor support.</target>
-        <jms:reference-file line="58">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+        <jms:reference-file line="75">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8388ff05103a22d0917788a48ccdc9716a353ac8" resname="ss.registration.registration_email_sent.text.no_ras_for_your_institution">
         <source>ss.registration.registration_email_sent.text.no_ras_for_your_institution</source>
         <target>Er zijn geen locaties beschikbaar binnen je instelling om je token te activeren. Neem contact op met je helpdesk voor support.</target>
-        <jms:reference-file line="76">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+        <jms:reference-file line="93">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c9ea58235246dd0f14a2d6aaed379ad0638d0e7" resname="ss.registration.registration_email_sent.text.registration_code_has_been_sent">
         <source>ss.registration.registration_email_sent.text.registration_code_has_been_sent</source>
         <target>Een e-mail met deze instructies en je activatiecode is ook naar het e-mailadres ‘%email%’ verstuurd.</target>
         <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="9cd651eed31a40300b9bdbe4eb6f43b47590ab13" resname="ss.registration.registration_email_sent.text.registration_code_has_been_sent_no_email">
+        <source>ss.registration.registration_email_sent.text.registration_code_has_been_sent_no_email</source>
+        <target>Mocht je (nog) geen toegang hebben tot dit e-mailadres dan kun je de instructies en activatiecode ook printen of downloaden.</target>
+        <jms:reference-file line="54">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="4cf581fa68d2c12db4d799554971856cbecc3e16" resname="ss.registration.registration_email_sent.text.registration_code_has_been_sent_pdf">
+        <source>ss.registration.registration_email_sent.text.registration_code_has_been_sent_pdf</source>
+        <target>PDF</target>
+        <jms:reference-file line="65">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="da18b75fb1c21ae87ec2ec68d747518bd2f3659f" resname="ss.registration.registration_email_sent.text.registration_code_has_been_sent_print">
+        <source>ss.registration.registration_email_sent.text.registration_code_has_been_sent_print</source>
+        <target>Print</target>
+        <jms:reference-file line="61">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ef48b4bbb1cef4ef12eb3e5146beb743e648752" resname="ss.registration.registration_email_sent.text.thank_you_for_registration">
         <source>ss.registration.registration_email_sent.text.thank_you_for_registration</source>
@@ -290,12 +305,12 @@
       <trans-unit id="536255f00c5e95be847f318b9a692596a9d927a2" resname="ss.registration.registration_email_sent.title.list_of_ra_locations">
         <source>ss.registration.registration_email_sent.title.list_of_ra_locations</source>
         <target>Locatie(s) om je token te activeren</target>
-        <jms:reference-file line="55">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+        <jms:reference-file line="72">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fad1d50cfe9eadd2b8c3dd3e10456e70a5c927f0" resname="ss.registration.registration_email_sent.title.list_of_ras">
         <source>ss.registration.registration_email_sent.title.list_of_ras</source>
         <target>Locatie(s) om je token te activeren</target>
-        <jms:reference-file line="73">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
+        <jms:reference-file line="90">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6348b54419006fd2ee31e33581af254358acd8e8" resname="ss.registration.selector.sms.alt">
         <source>ss.registration.selector.sms.alt</source>

--- a/app/Resources/translations/validators.en_GB.xliff
+++ b/app/Resources/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-22T13:14:28Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-01-22T13:59:08Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/validators.nl_NL.xliff
+++ b/app/Resources/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-22T13:14:23Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-01-22T13:59:02Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -10,7 +10,7 @@
     '@SurfnetStepupSelfServiceSelfServiceBundle/Resources/public/less/style.less'
     '@SurfnetStepupBundle/Resources/public/less/stepup.less'
     %}
-    <link href="{{ asset_url }}" type="text/css" rel="stylesheet" media="screen" />
+    <link href="{{ asset_url }}" type="text/css" rel="stylesheet" media="screen, print" />
     {% endstylesheets %}
 {% endblock head_style %}
 
@@ -27,7 +27,7 @@
                 <h2>{{ 'app.subname'|trans }}</h2>
             </div>
         {% if app.user %}
-            <div class="clearfix">
+            <div class="clearfix page-header-user">
                 <form method="post" action="{{ logout_url('saml_based') }}" class="pull-right">
                     <button type="submit" class="btn btn-link">
                         <i class="fa fa-sign-out"></i>

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "surfnet/stepup-bundle": "^2.0",
         "surfnet/stepup-u2f-bundle": "dev-develop",
         "mopa/composer-bridge": "~1.5",
-        "openconext/monitor-bundle": "^1.0"
+        "openconext/monitor-bundle": "^1.0",
+        "mpdf/mpdf": "^7.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b38783a635508674f0cfa60be08d8db",
+    "content-hash": "5e78423bf85dc156669e61aa49d47daa",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1382,6 +1382,73 @@
             "time": "2015-10-01T19:20:19+00:00"
         },
         {
+            "name": "mpdf/mpdf",
+            "version": "v7.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mpdf/mpdf.git",
+                "reference": "5681a0cae1eea197143d5d27f06e19b0523cd8d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mpdf/mpdf/zipball/5681a0cae1eea197143d5d27f06e19b0523cd8d6",
+                "reference": "5681a0cae1eea197143d5d27f06e19b0523cd8d6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "ext-mbstring": "*",
+                "paragonie/random_compat": "^1.4|^2.0",
+                "php": "^5.6 || ~7.0.0 || ~7.1.0 || ~7.2.0",
+                "psr/log": "^1.0",
+                "setasign/fpdi": "1.6.*"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.5",
+                "phpunit/phpunit": "^5.0",
+                "squizlabs/php_codesniffer": "^2.7.0",
+                "tracy/tracy": "^2.4"
+            },
+            "suggest": {
+                "ext-bcmath": "Needed for generation of some types of barcodes",
+                "ext-xml": "Needed mainly for SVG manipulation",
+                "ext-zlib": "Needed for compression of embedded resources, such as fonts"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-development": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mpdf\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Matěj Humpál",
+                    "role": "Developer, maintainer"
+                },
+                {
+                    "name": "Ian Back",
+                    "role": "Developer (retired)"
+                }
+            ],
+            "description": "A PHP class to generate PDF files from HTML with Unicode/UTF-8 and CJK support",
+            "homepage": "https://mpdf.github.io",
+            "keywords": [
+                "pdf",
+                "php",
+                "utf-8"
+            ],
+            "time": "2018-01-03T07:32:36+00:00"
+        },
+        {
             "name": "nelmio/security-bundle",
             "version": "1.10.0",
             "source": {
@@ -1968,6 +2035,55 @@
             ],
             "description": "A security checker for your composer.lock",
             "time": "2015-05-28T14:22:40+00:00"
+        },
+        {
+            "name": "setasign/fpdi",
+            "version": "1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDI.git",
+                "reference": "a6ad58897a6d97cc2d2cd2adaeda343b25a368ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/a6ad58897a6d97cc2d2cd2adaeda343b25a368ea",
+                "reference": "a6ad58897a6d97cc2d2cd2adaeda343b25a368ea",
+                "shasum": ""
+            },
+            "suggest": {
+                "setasign/fpdf": "FPDI will extend this class but as it is also possible to use \"tecnickcom/tcpdf\" as an alternative there's no fixed dependency configured.",
+                "setasign/fpdi-fpdf": "Use this package to automatically evaluate dependencies to FPDF.",
+                "setasign/fpdi-tcpdf": "Use this package to automatically evaluate dependencies to TCPDF."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "filters/",
+                    "fpdi.php",
+                    "fpdf_tpl.php",
+                    "fpdi_pdf_parser.php",
+                    "pdf_context.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Slabon",
+                    "email": "jan.slabon@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                }
+            ],
+            "description": "FPDI is a collection of PHP classes facilitating developers to read pages from existing PDF documents and use them as templates in FPDF. Because it is also possible to use FPDI with TCPDF, there are no fixed dependencies defined. Please see suggestions for packages which evaluates the dependencies automatically.",
+            "homepage": "https://www.setasign.com/fpdi",
+            "keywords": [
+                "fpdf",
+                "fpdi",
+                "pdf"
+            ],
+            "time": "2017-05-11T14:25:49+00:00"
         },
         {
             "name": "simplesamlphp/saml2",

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
@@ -19,6 +19,8 @@
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Controller;
 
 use DateInterval;
+use Mpdf\Mpdf;
+use Mpdf\Output\Destination as MpdfDestination;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SecondFactorService;
 use Symfony\Component\HttpFoundation\Request;
@@ -128,6 +130,7 @@ class RegistrationController extends Controller
 
         $parameters = [
             'email'            => $identity->email,
+            'secondFactorId'   => $secondFactor->id,
             'registrationCode' => $secondFactor->registrationCode,
             'expirationDate'   => $secondFactor->registrationRequestedAt->add(
                 new DateInterval('P14D')
@@ -154,5 +157,23 @@ class RegistrationController extends Controller
             'SurfnetStepupSelfServiceSelfServiceBundle:Registration:registrationEmailSent.html.twig',
             $parameters
         );
+    }
+
+    /**
+     * @param $secondFactorId
+     * @return Response
+     *
+     * @SuppressWarnings(PHPMD.ExitExpression) MPDF requires bypassing Symfony, so we exit() when MPDF is done.
+     */
+    public function registrationPdfAction($secondFactorId)
+    {
+        $content = $this->registrationEmailSentAction($secondFactorId)
+            ->getContent();
+
+        $mpdf = new Mpdf();
+        $mpdf->WriteHTML($content);
+        $mpdf->Output('registration-code.pdf', MpdfDestination::DOWNLOAD);
+
+        exit;
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
@@ -40,6 +40,11 @@ ss_registration_registration_email_sent:
     methods:  [GET]
     defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:Registration:registrationEmailSent }
 
+ss_registration_registration_pdf:
+    path:     /registration/{secondFactorId}/registration-pdf
+    methods:  [GET]
+    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:Registration:registrationPdf }
+
 ss_registration_yubikey_prove_possession:
     path:     /registration/yubikey/prove-possession
     methods:  [GET,POST]

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/js/registration-print.js
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/js/registration-print.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jQuery(function ($) {
+
+    $('a.registration-print').on('click', function(e) {
+        e.preventDefault();
+
+        window.print();
+    });
+
+});

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
@@ -99,3 +99,16 @@ select[name="stepup_switch_locale[locale]"] {
 .text-extra-muted {
     color: #cccccc;
 }
+
+@media print {
+    footer,
+    .page-header-user,
+    .progress-steps,
+    .progress {
+        display: none !important;
+    }
+
+    .page-header {
+        border-bottom: none;
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
@@ -100,11 +100,23 @@ select[name="stepup_switch_locale[locale]"] {
     color: #cccccc;
 }
 
+.registration-print-options a {
+    display: inline-flex;
+    line-height: 2em;
+    margin-right: 2em;
+    vertical-align: middle;
+
+    i.fa {
+        margin-right: 5px;
+    }
+}
+
 @media print {
     footer,
     .page-header-user,
     .progress-steps,
-    .progress {
+    .progress,
+    .registration-print-options {
         display: none !important;
     }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/registrationEmailSent.html.twig
@@ -49,6 +49,23 @@
 
     <p>{{ 'ss.registration.registration_email_sent.text.registration_code_has_been_sent'|trans({'%email%': email}) }}</p>
 
+    <div class="registration-print-options">
+        {% if not verifyEmail %}
+            <p>{{ 'ss.registration.registration_email_sent.text.registration_code_has_been_sent_no_email'|trans }}</p>
+        {% endif %}
+
+        <br />
+
+        <a href="#" class="registration-print">
+            <i class="fa fa-print fa-2x"></i>
+            {{ 'ss.registration.registration_email_sent.text.registration_code_has_been_sent_print'|trans }}
+        </a>
+        <a href="{{ path('ss_registration_registration_pdf', {'secondFactorId': secondFactorId}) }}" class="registration-pdf">
+            <i class="fa fa-download fa-2x"></i>
+            {{ 'ss.registration.registration_email_sent.text.registration_code_has_been_sent_pdf'|trans }}
+        </a>
+    </div>
+
     <hr>
 
     {% if raLocations is defined %}
@@ -89,3 +106,9 @@
         {% endif %}
     {% endif %}
 {% endblock %}
+
+{% block body_end %}
+    {% javascripts '@SurfnetStepupSelfServiceSelfServiceBundle/Resources/public/js/registration-print.js' %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock body_end %}


### PR DESCRIPTION
The MPDF library is used to render the confirmation page
server-side. This output of the 'email sent' action is used to
generate the PDF. The print stylesheets are used by MPDF to get more
or less the same look and feel as the browser-printed webpage.
    
In order for the logo to be embedded in the PDF, php-gd is introduced
as a new dependency. If php-gd is not installed, a red cross will
appear on the PDF where the logo should be.