### PR TITLE
Use the system temp directory for Mpdf temporary storage

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
@@ -170,7 +170,11 @@ class RegistrationController extends Controller
         $content = $this->registrationEmailSentAction($secondFactorId)
             ->getContent();
 
-        $mpdf = new Mpdf();
+        $mpdf = new Mpdf(
+            array(
+                'tempDir' => sys_get_temp_dir(),
+            )
+        );
         $mpdf->WriteHTML($content);
         $mpdf->Output('registration-code.pdf', MpdfDestination::DOWNLOAD);
 


### PR DESCRIPTION
The Mpdf default is to write temporary files to '../../tmp', which in
our case is not a suitable directory. We explicitly tell Mpdf to use
the sys_get_temp_dir folder, which will use the system
default (depending on production setup, probably a private tmp dir for
php-fpm).