### PR TITLE
Stop assuming Tiqr is the only GSSP

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-14T13:50:48Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-03-14T14:02:58Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -432,12 +432,12 @@ For all devices with a USB port.</target>
       <trans-unit id="a9291ad7b24d9af72187ad2c3a47ef70a8ddb049" resname="ss.registration.u2f.alert.device_reported_an_error">
         <source>ss.registration.u2f.alert.device_reported_an_error</source>
         <target>The U2F device reported an error. Try again or visit your IT helpdesk.</target>
-        <jms:reference-file line="49">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="47">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="10942aeeff49e9078c3388325521ec7745d9e4d7" resname="ss.registration.u2f.alert.error">
         <source>ss.registration.u2f.alert.error</source>
         <target>The registration of the U2F device failed. Try again or visit your IT helpdesk.</target>
-        <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="48">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c0ebdb3c75c5ba291acea30db4475b037706e33" resname="ss.registration.u2f.button.retry">
         <source>ss.registration.u2f.button.retry</source>
@@ -541,12 +541,12 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="6ddd63626b39582e37d8f3012d893e9d4eac14db" resname="ss.second_factor.revoke.alert.revocation_failed">
         <source>ss.second_factor.revoke.alert.revocation_failed</source>
         <target>Token revocation failed</target>
-        <jms:reference-file line="46">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="44">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f990ac6c55a5585b8c3cde21f4c63bb66b055892" resname="ss.second_factor.revoke.alert.revocation_successful">
         <source>ss.second_factor.revoke.alert.revocation_successful</source>
         <target>Your token has been removed.</target>
-        <jms:reference-file line="45">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="43">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
         <source>ss.second_factor.revoke.button.revoke</source>
@@ -558,25 +558,15 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
         <target>Test</target>
         <jms:reference-file line="58">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="6fb0acf21df652aef6e8da27aefff89ad52b6e1a" resname="ss.second_factor.revoke.second_factor_type.biometric">
-        <source>ss.second_factor.revoke.second_factor_type.biometric</source>
-        <target>Biometric</target>
-        <jms:reference-file line="44">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="8cb0dc5d3faca805d69dce7496307078d2234dfb" resname="ss.second_factor.revoke.second_factor_type.sms">
         <source>ss.second_factor.revoke.second_factor_type.sms</source>
         <target>SMS</target>
         <jms:reference-file line="40">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="ddaf3dc5c270fff8b10c72c1385407f79b7fbd0b" resname="ss.second_factor.revoke.second_factor_type.tiqr">
-        <source>ss.second_factor.revoke.second_factor_type.tiqr</source>
-        <target>Tiqr</target>
-        <jms:reference-file line="42">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="05f193ed2a057ba345519da22753939ba8aef925" resname="ss.second_factor.revoke.second_factor_type.u2f">
         <source>ss.second_factor.revoke.second_factor_type.u2f</source>
         <target>U2F</target>
-        <jms:reference-file line="43">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="42">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="41ef2c1782e52dabce59e7be54aef6fa07829959" resname="ss.second_factor.revoke.second_factor_type.yubikey">
         <source>ss.second_factor.revoke.second_factor_type.yubikey</source>
@@ -651,12 +641,12 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="cbdf2c4bacdae4b97285b0201968c2d3a9de1be1" resname="ss.test_second_factor.verification_failed">
         <source>ss.test_second_factor.verification_failed</source>
         <target>The test with your token failed.</target>
-        <jms:reference-file line="54">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="52">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c0f4f14de1d3c98032305d9af18fad28ec67456" resname="ss.test_second_factor.verification_successful">
         <source>ss.test_second_factor.verification_successful</source>
         <target>The test with your token was successful. You can login with Strong Authentication.</target>
-        <jms:reference-file line="53">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="51">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dc4478bd45a81c1a45020aac9d22d73abc5f1455" resname="ss.verify_yubikey_command.otp.otp_invalid">
         <source>ss.verify_yubikey_command.otp.otp_invalid</source>

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-22T13:59:08Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-03-14T13:50:48Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -432,12 +432,12 @@ For all devices with a USB port.</target>
       <trans-unit id="a9291ad7b24d9af72187ad2c3a47ef70a8ddb049" resname="ss.registration.u2f.alert.device_reported_an_error">
         <source>ss.registration.u2f.alert.device_reported_an_error</source>
         <target>The U2F device reported an error. Try again or visit your IT helpdesk.</target>
-        <jms:reference-file line="51">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="49">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="10942aeeff49e9078c3388325521ec7745d9e4d7" resname="ss.registration.u2f.alert.error">
         <source>ss.registration.u2f.alert.error</source>
         <target>The registration of the U2F device failed. Try again or visit your IT helpdesk.</target>
-        <jms:reference-file line="52">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c0ebdb3c75c5ba291acea30db4475b037706e33" resname="ss.registration.u2f.button.retry">
         <source>ss.registration.u2f.button.retry</source>
@@ -541,12 +541,12 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="6ddd63626b39582e37d8f3012d893e9d4eac14db" resname="ss.second_factor.revoke.alert.revocation_failed">
         <source>ss.second_factor.revoke.alert.revocation_failed</source>
         <target>Token revocation failed</target>
-        <jms:reference-file line="48">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="46">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f990ac6c55a5585b8c3cde21f4c63bb66b055892" resname="ss.second_factor.revoke.alert.revocation_successful">
         <source>ss.second_factor.revoke.alert.revocation_successful</source>
         <target>Your token has been removed.</target>
-        <jms:reference-file line="47">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="45">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
         <source>ss.second_factor.revoke.button.revoke</source>
@@ -561,27 +561,27 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="6fb0acf21df652aef6e8da27aefff89ad52b6e1a" resname="ss.second_factor.revoke.second_factor_type.biometric">
         <source>ss.second_factor.revoke.second_factor_type.biometric</source>
         <target>Biometric</target>
-        <jms:reference-file line="46">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="44">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8cb0dc5d3faca805d69dce7496307078d2234dfb" resname="ss.second_factor.revoke.second_factor_type.sms">
         <source>ss.second_factor.revoke.second_factor_type.sms</source>
         <target>SMS</target>
-        <jms:reference-file line="42">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="40">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ddaf3dc5c270fff8b10c72c1385407f79b7fbd0b" resname="ss.second_factor.revoke.second_factor_type.tiqr">
         <source>ss.second_factor.revoke.second_factor_type.tiqr</source>
         <target>Tiqr</target>
-        <jms:reference-file line="44">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="42">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="05f193ed2a057ba345519da22753939ba8aef925" resname="ss.second_factor.revoke.second_factor_type.u2f">
         <source>ss.second_factor.revoke.second_factor_type.u2f</source>
         <target>U2F</target>
-        <jms:reference-file line="45">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="43">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="41ef2c1782e52dabce59e7be54aef6fa07829959" resname="ss.second_factor.revoke.second_factor_type.yubikey">
         <source>ss.second_factor.revoke.second_factor_type.yubikey</source>
         <target>YubiKey</target>
-        <jms:reference-file line="43">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="41">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="aff5bdb50adaae6a777fd46f760f426e6c847867" resname="ss.second_factor.revoke.table_header.second_factor.identifier">
         <source>ss.second_factor.revoke.table_header.second_factor.identifier</source>
@@ -603,25 +603,15 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
         <target>Remove token</target>
         <jms:reference-file line="4">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/revoke.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="58c4d4601f77fde80d101525a27c16d0c35ae651" resname="ss.second_factor.type.biometric">
-        <source>ss.second_factor.type.biometric</source>
-        <target>Biometric</target>
-        <jms:reference-file line="39">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="46d5571724a558b0ad7e823e35a35021d78ed209" resname="ss.second_factor.type.sms">
         <source>ss.second_factor.type.sms</source>
         <target>SMS</target>
         <jms:reference-file line="35">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="84f85f9b2badc618045be40abbd82d1a1acc3e3f" resname="ss.second_factor.type.tiqr">
-        <source>ss.second_factor.type.tiqr</source>
-        <target>Tiqr</target>
-        <jms:reference-file line="37">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="e6a4121e1e5da569eb89ea885f61ea68033650eb" resname="ss.second_factor.type.u2f">
         <source>ss.second_factor.type.u2f</source>
         <target>U2F</target>
-        <jms:reference-file line="38">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="37">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="81b817f201c14a06e97251089f38fec70163ef3f" resname="ss.second_factor.type.yubikey">
         <source>ss.second_factor.type.yubikey</source>
@@ -661,12 +651,12 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="cbdf2c4bacdae4b97285b0201968c2d3a9de1be1" resname="ss.test_second_factor.verification_failed">
         <source>ss.test_second_factor.verification_failed</source>
         <target>The test with your token failed.</target>
-        <jms:reference-file line="56">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="54">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c0f4f14de1d3c98032305d9af18fad28ec67456" resname="ss.test_second_factor.verification_successful">
         <source>ss.test_second_factor.verification_successful</source>
         <target>The test with your token was successful. You can login with Strong Authentication.</target>
-        <jms:reference-file line="55">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="53">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dc4478bd45a81c1a45020aac9d22d73abc5f1455" resname="ss.verify_yubikey_command.otp.otp_invalid">
         <source>ss.verify_yubikey_command.otp.otp_invalid</source>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-22T13:59:02Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-03-14T13:50:42Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -432,12 +432,12 @@ Geschikt voor alle devices met een USB-poort.</target>
       <trans-unit id="a9291ad7b24d9af72187ad2c3a47ef70a8ddb049" resname="ss.registration.u2f.alert.device_reported_an_error">
         <source>ss.registration.u2f.alert.device_reported_an_error</source>
         <target>Het U2F-apparaat heeft een foutmelding gerapporteerd. Probeer het opnieuw of neem contact op met de IT-helpdesk.</target>
-        <jms:reference-file line="51">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="49">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="10942aeeff49e9078c3388325521ec7745d9e4d7" resname="ss.registration.u2f.alert.error">
         <source>ss.registration.u2f.alert.error</source>
         <target>De registratie van het U2F-apparaat is mislukt. Probeer het opnieuw of neem contact op met de IT-helpdesk.</target>
-        <jms:reference-file line="52">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c0ebdb3c75c5ba291acea30db4475b037706e33" resname="ss.registration.u2f.button.retry">
         <source>ss.registration.u2f.button.retry</source>
@@ -539,12 +539,12 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="6ddd63626b39582e37d8f3012d893e9d4eac14db" resname="ss.second_factor.revoke.alert.revocation_failed">
         <source>ss.second_factor.revoke.alert.revocation_failed</source>
         <target>Token intrekken is mislukt</target>
-        <jms:reference-file line="48">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="46">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f990ac6c55a5585b8c3cde21f4c63bb66b055892" resname="ss.second_factor.revoke.alert.revocation_successful">
         <source>ss.second_factor.revoke.alert.revocation_successful</source>
         <target>Je token is verwijderd.</target>
-        <jms:reference-file line="47">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="45">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
         <source>ss.second_factor.revoke.button.revoke</source>
@@ -559,27 +559,27 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="6fb0acf21df652aef6e8da27aefff89ad52b6e1a" resname="ss.second_factor.revoke.second_factor_type.biometric">
         <source>ss.second_factor.revoke.second_factor_type.biometric</source>
         <target>Biometrie</target>
-        <jms:reference-file line="46">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="44">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8cb0dc5d3faca805d69dce7496307078d2234dfb" resname="ss.second_factor.revoke.second_factor_type.sms">
         <source>ss.second_factor.revoke.second_factor_type.sms</source>
         <target>SMS</target>
-        <jms:reference-file line="42">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="40">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ddaf3dc5c270fff8b10c72c1385407f79b7fbd0b" resname="ss.second_factor.revoke.second_factor_type.tiqr">
         <source>ss.second_factor.revoke.second_factor_type.tiqr</source>
         <target>Tiqr</target>
-        <jms:reference-file line="44">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="42">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="05f193ed2a057ba345519da22753939ba8aef925" resname="ss.second_factor.revoke.second_factor_type.u2f">
         <source>ss.second_factor.revoke.second_factor_type.u2f</source>
         <target>U2F</target>
-        <jms:reference-file line="45">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="43">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="41ef2c1782e52dabce59e7be54aef6fa07829959" resname="ss.second_factor.revoke.second_factor_type.yubikey">
         <source>ss.second_factor.revoke.second_factor_type.yubikey</source>
         <target>YubiKey</target>
-        <jms:reference-file line="43">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="41">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="aff5bdb50adaae6a777fd46f760f426e6c847867" resname="ss.second_factor.revoke.table_header.second_factor.identifier">
         <source>ss.second_factor.revoke.table_header.second_factor.identifier</source>
@@ -601,25 +601,15 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
         <target>Verwijder token</target>
         <jms:reference-file line="4">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/revoke.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="58c4d4601f77fde80d101525a27c16d0c35ae651" resname="ss.second_factor.type.biometric">
-        <source>ss.second_factor.type.biometric</source>
-        <target>Biometrie</target>
-        <jms:reference-file line="39">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="46d5571724a558b0ad7e823e35a35021d78ed209" resname="ss.second_factor.type.sms">
         <source>ss.second_factor.type.sms</source>
         <target>SMS</target>
         <jms:reference-file line="35">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="84f85f9b2badc618045be40abbd82d1a1acc3e3f" resname="ss.second_factor.type.tiqr">
-        <source>ss.second_factor.type.tiqr</source>
-        <target>Tiqr</target>
-        <jms:reference-file line="37">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="e6a4121e1e5da569eb89ea885f61ea68033650eb" resname="ss.second_factor.type.u2f">
         <source>ss.second_factor.type.u2f</source>
         <target>U2F</target>
-        <jms:reference-file line="38">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="37">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="81b817f201c14a06e97251089f38fec70163ef3f" resname="ss.second_factor.type.yubikey">
         <source>ss.second_factor.type.yubikey</source>
@@ -659,12 +649,12 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="cbdf2c4bacdae4b97285b0201968c2d3a9de1be1" resname="ss.test_second_factor.verification_failed">
         <source>ss.test_second_factor.verification_failed</source>
         <target>De test met je token is mislukt.</target>
-        <jms:reference-file line="56">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="54">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c0f4f14de1d3c98032305d9af18fad28ec67456" resname="ss.test_second_factor.verification_successful">
         <source>ss.test_second_factor.verification_successful</source>
         <target>De test met je token is geslaagd. Je kunt inloggen met Sterke Authenticatie.</target>
-        <jms:reference-file line="55">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="53">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dc4478bd45a81c1a45020aac9d22d73abc5f1455" resname="ss.verify_yubikey_command.otp.otp_invalid">
         <source>ss.verify_yubikey_command.otp.otp_invalid</source>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-14T13:50:42Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-03-14T14:02:54Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -432,12 +432,12 @@ Geschikt voor alle devices met een USB-poort.</target>
       <trans-unit id="a9291ad7b24d9af72187ad2c3a47ef70a8ddb049" resname="ss.registration.u2f.alert.device_reported_an_error">
         <source>ss.registration.u2f.alert.device_reported_an_error</source>
         <target>Het U2F-apparaat heeft een foutmelding gerapporteerd. Probeer het opnieuw of neem contact op met de IT-helpdesk.</target>
-        <jms:reference-file line="49">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="47">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="10942aeeff49e9078c3388325521ec7745d9e4d7" resname="ss.registration.u2f.alert.error">
         <source>ss.registration.u2f.alert.error</source>
         <target>De registratie van het U2F-apparaat is mislukt. Probeer het opnieuw of neem contact op met de IT-helpdesk.</target>
-        <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="48">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c0ebdb3c75c5ba291acea30db4475b037706e33" resname="ss.registration.u2f.button.retry">
         <source>ss.registration.u2f.button.retry</source>
@@ -539,12 +539,12 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="6ddd63626b39582e37d8f3012d893e9d4eac14db" resname="ss.second_factor.revoke.alert.revocation_failed">
         <source>ss.second_factor.revoke.alert.revocation_failed</source>
         <target>Token intrekken is mislukt</target>
-        <jms:reference-file line="46">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="44">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f990ac6c55a5585b8c3cde21f4c63bb66b055892" resname="ss.second_factor.revoke.alert.revocation_successful">
         <source>ss.second_factor.revoke.alert.revocation_successful</source>
         <target>Je token is verwijderd.</target>
-        <jms:reference-file line="45">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="43">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
         <source>ss.second_factor.revoke.button.revoke</source>
@@ -556,25 +556,15 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
         <target>Testen</target>
         <jms:reference-file line="58">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="6fb0acf21df652aef6e8da27aefff89ad52b6e1a" resname="ss.second_factor.revoke.second_factor_type.biometric">
-        <source>ss.second_factor.revoke.second_factor_type.biometric</source>
-        <target>Biometrie</target>
-        <jms:reference-file line="44">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="8cb0dc5d3faca805d69dce7496307078d2234dfb" resname="ss.second_factor.revoke.second_factor_type.sms">
         <source>ss.second_factor.revoke.second_factor_type.sms</source>
         <target>SMS</target>
         <jms:reference-file line="40">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="ddaf3dc5c270fff8b10c72c1385407f79b7fbd0b" resname="ss.second_factor.revoke.second_factor_type.tiqr">
-        <source>ss.second_factor.revoke.second_factor_type.tiqr</source>
-        <target>Tiqr</target>
-        <jms:reference-file line="42">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="05f193ed2a057ba345519da22753939ba8aef925" resname="ss.second_factor.revoke.second_factor_type.u2f">
         <source>ss.second_factor.revoke.second_factor_type.u2f</source>
         <target>U2F</target>
-        <jms:reference-file line="43">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="42">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="41ef2c1782e52dabce59e7be54aef6fa07829959" resname="ss.second_factor.revoke.second_factor_type.yubikey">
         <source>ss.second_factor.revoke.second_factor_type.yubikey</source>
@@ -649,12 +639,12 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="cbdf2c4bacdae4b97285b0201968c2d3a9de1be1" resname="ss.test_second_factor.verification_failed">
         <source>ss.test_second_factor.verification_failed</source>
         <target>De test met je token is mislukt.</target>
-        <jms:reference-file line="54">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="52">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c0f4f14de1d3c98032305d9af18fad28ec67456" resname="ss.test_second_factor.verification_successful">
         <source>ss.test_second_factor.verification_successful</source>
         <target>De test met je token is geslaagd. Je kunt inloggen met Sterke Authenticatie.</target>
-        <jms:reference-file line="53">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="51">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dc4478bd45a81c1a45020aac9d22d73abc5f1455" resname="ss.verify_yubikey_command.otp.otp_invalid">
         <source>ss.verify_yubikey_command.otp.otp_invalid</source>

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "surfnet/stepup-middleware-client-bundle": "^2.0",
         "guzzlehttp/guzzle": "^6",
         "surfnet/stepup-saml-bundle": "^3.0",
-        "surfnet/stepup-bundle": "^2.0",
+        "surfnet/stepup-bundle": "^3.2",
         "surfnet/stepup-u2f-bundle": "dev-develop",
         "mopa/composer-bridge": "~1.5",
         "openconext/monitor-bundle": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e78423bf85dc156669e61aa49d47daa",
+    "content-hash": "2c24ce64cd71da7aeed7ee158a23a40f",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2144,16 +2144,16 @@
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "2.0.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-bundle.git",
-                "reference": "0766c91a6b391739d9fe4693f684ef1332342df4"
+                "reference": "547c5bcb8fe1841fa657bbf43c5ea4b8e575ec3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/0766c91a6b391739d9fe4693f684ef1332342df4",
-                "reference": "0766c91a6b391739d9fe4693f684ef1332342df4",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/547c5bcb8fe1841fa657bbf43c5ea4b8e575ec3a",
+                "reference": "547c5bcb8fe1841fa657bbf43c5ea4b8e575ec3a",
                 "shasum": ""
             },
             "require": {
@@ -2197,7 +2197,7 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2017-06-14T13:03:51+00:00"
+            "time": "2018-03-14T13:11:17+00:00"
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",

--- a/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/DependencyInjection/Compiler/ViewConfigCollectionPass.php
+++ b/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/DependencyInjection/Compiler/ViewConfigCollectionPass.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SamlStepupProviderBundle\DependencyInjection\Compiler;
+
+use Surfnet\StepupSelfService\SamlStepupProviderBundle\DependencyInjection\SurfnetStepupSelfServiceSamlStepupProviderExtension;
+use Surfnet\StepupSelfService\SamlStepupProviderBundle\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ViewConfigCollectionPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('surfnet_stepup.provider.collection')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('surfnet_stepup.provider.collection');
+        $taggedServices = $container->findTaggedServiceIds(
+            SurfnetStepupSelfServiceSamlStepupProviderExtension::VIEW_CONFIG_TAG_NAME
+        );
+
+        $taggedServices = array_keys($taggedServices);
+
+        foreach ($taggedServices as $id) {
+            preg_match('/^gssp\.view_config\.(\w+)$/', $id, $gsspIdMatches);
+            if (!is_array($gsspIdMatches)) {
+                throw new InvalidConfigurationException('A manually tagged view config service was named incorrectly.');
+            }
+            $definition->addMethodCall('addViewConfig', [new Reference($id), end($gsspIdMatches)]);
+        }
+    }
+}

--- a/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/DependencyInjection/SurfnetStepupSelfServiceSamlStepupProviderExtension.php
+++ b/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/DependencyInjection/SurfnetStepupSelfServiceSamlStepupProviderExtension.php
@@ -28,6 +28,8 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class SurfnetStepupSelfServiceSamlStepupProviderExtension extends Extension
 {
+    const VIEW_CONFIG_TAG_NAME = 'gssp.view_config';
+
     /**
      * {@inheritdoc}
      */
@@ -100,7 +102,7 @@ class SurfnetStepupSelfServiceSamlStepupProviderExtension extends Extension
         );
 
         $viewConfigDefinition = new Definition('Surfnet\StepupSelfService\SamlStepupProviderBundle\Provider\ViewConfig', [
-            new Reference('request'),
+            new Reference('request_stack'),
             $configuration['view_config']['loa'],
             $configuration['view_config']['logo'],
             $configuration['view_config']['app_android_url'],
@@ -115,7 +117,7 @@ class SurfnetStepupSelfServiceSamlStepupProviderExtension extends Extension
             $configuration['view_config']['authn_failed'],
             $configuration['view_config']['pop_failed'],
         ]);
-        $viewConfigDefinition->setScope('request');
+        $viewConfigDefinition->addTag(self::VIEW_CONFIG_TAG_NAME);
 
         $container->setDefinition('gssp.view_config.' . $provider, $viewConfigDefinition);
 

--- a/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/Provider/ViewConfig.php
+++ b/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/Provider/ViewConfig.php
@@ -18,10 +18,11 @@
 
 namespace Surfnet\StepupSelfService\SamlStepupProviderBundle\Provider;
 
+use Surfnet\StepupBundle\Value\Provider\ViewConfigInterface;
 use Surfnet\StepupSelfService\SelfServiceBundle\Exception\LogicException;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
-class ViewConfig
+class ViewConfig implements ViewConfigInterface
 {
     /**
      * @var string
@@ -79,9 +80,9 @@ class ViewConfig
     private $popFailed;
 
     /**
-     * @var Request
+     * @var RequestStack
      */
-    private $request;
+    private $requestStack;
 
     /**
      * @var string
@@ -96,7 +97,7 @@ class ViewConfig
     /**
      * The arrays are arrays of translated text, indexed on locale.
      *
-     * @param Request $request
+     * @param RequestStack $requestStack
      * @param string $loa
      * @param string $logo
      * @param string $androidUrl
@@ -113,7 +114,7 @@ class ViewConfig
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
-        Request $request,
+        RequestStack $requestStack,
         $loa,
         $logo,
         $androidUrl,
@@ -141,7 +142,7 @@ class ViewConfig
         $this->explanation = $explanation;
         $this->authnFailed = $authnFailed;
         $this->popFailed = $popFailed;
-        $this->request = $request;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -255,7 +256,7 @@ class ViewConfig
      */
     private function getTranslation(array $translations)
     {
-        $currentLocale = $this->request->getLocale();
+        $currentLocale = $this->requestStack->getCurrentRequest()->getLocale();
         if (is_null($currentLocale)) {
             throw new LogicException('The current language is not set');
         }

--- a/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/SurfnetStepupSelfServiceSamlStepupProviderBundle.php
+++ b/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/SurfnetStepupSelfServiceSamlStepupProviderBundle.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupSelfService\SamlStepupProviderBundle;
 
 use Surfnet\StepupSelfService\SamlStepupProviderBundle\DependencyInjection\Compiler\StateHandlerSessionPass;
+use Surfnet\StepupSelfService\SamlStepupProviderBundle\DependencyInjection\Compiler\ViewConfigCollectionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,5 +28,6 @@ class SurfnetStepupSelfServiceSamlStepupProviderBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new StateHandlerSessionPass());
+        $container->addCompilerPass(new ViewConfigCollectionPass());
     }
 }

--- a/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/Tests/Provider/ViewConfigTest.php
+++ b/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/Tests/Provider/ViewConfigTest.php
@@ -21,7 +21,7 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Tests\DependencyInjection;
 use Mockery as m;
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\StepupSelfService\SamlStepupProviderBundle\Provider\ViewConfig;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Tests the ViewConfig class
@@ -91,8 +91,8 @@ final class ViewConfigTest extends TestCase
      */
     private function buildViewConfig($locale = '')
     {
-        $request = m::mock(Request::class);
-        $request->shouldReceive('getLocale')->andReturn($locale)->byDefault();
+        $request = m::mock(RequestStack::class);
+        $request->shouldReceive('getCurrentRequest->getLocale')->andReturn($locale)->byDefault();
         return new ViewConfig(
             $request,
             3,

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -153,3 +153,11 @@ services:
             - "@request_stack"
             - '' # See extension
             - [] # See extension
+
+    # Twig
+    ra.twig.second_factor_type:
+        class: Surfnet\StepupSelfService\SelfServiceBundle\Twig\Extensions\Extension\SecondFactorType
+        arguments:
+            - "@surfnet_stepup.service.second_factor_type_translator"
+        tags:
+            - { name : twig.extension }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -48,7 +48,7 @@
                     <tbody>
                     {% for secondFactor in secondFactorCollection.elements %}
                         <tr>
-                            <td>{{ ('ss.second_factor.type.'~secondFactor.type)|trans }}</td>
+                            <td>{{ secondFactor.type|trans_second_factor_type }}</td>
                             <td>{{ secondFactor.secondFactorIdentifier }}</td>
                             <td>
                                 <div class="btn-group pull-right" role="group">

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/revoke.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/revoke.html.twig
@@ -12,7 +12,7 @@
         <tbody>
         <tr>
             <th scope="row">{{ 'ss.second_factor.revoke.table_header.type'|trans }}</th>
-            <td>{{ ('ss.second_factor.revoke.second_factor_type.' ~ secondFactor.type)|trans }}</td>
+            <td>{{ secondFactor.type|trans_second_factor_type }}</td>
         </tr>
         <tr>
             <th scope="row">{{ 'ss.second_factor.revoke.table_header.second_factor.identifier'|trans }}</th>

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig
@@ -39,9 +39,7 @@
 {# SecondFactorController revoke #}
 {{ 'ss.second_factor.revoke.second_factor_type.sms'|trans }}
 {{ 'ss.second_factor.revoke.second_factor_type.yubikey'|trans }}
-{{ 'ss.second_factor.revoke.second_factor_type.tiqr'|trans }}
 {{ 'ss.second_factor.revoke.second_factor_type.u2f'|trans }}
-{{ 'ss.second_factor.revoke.second_factor_type.biometric'|trans }}
 {{ 'ss.second_factor.revoke.alert.revocation_successful'|trans }}
 {{ 'ss.second_factor.revoke.alert.revocation_failed'|trans }}
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig
@@ -34,9 +34,7 @@
 {{ 'ss.second_factor.list.text.unverified'|trans }}
 {{ 'ss.second_factor.type.sms'|trans }}
 {{ 'ss.second_factor.type.yubikey'|trans }}
-{{ 'ss.second_factor.type.tiqr'|trans }}
 {{ 'ss.second_factor.type.u2f'|trans }}
-{{ 'ss.second_factor.type.biometric'|trans }}
 
 {# SecondFactorController revoke #}
 {{ 'ss.second_factor.revoke.second_factor_type.sms'|trans }}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Twig/Extensions/Extension/SecondFactorType.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Twig/Extensions/Extension/SecondFactorType.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Twig\Extensions\Extension;
+
+use Surfnet\StepupBundle\Service\SecondFactorTypeTranslationService;
+use Twig_Extension;
+use Twig_SimpleFilter;
+
+final class SecondFactorType extends Twig_Extension
+{
+    /**
+     * @var SecondFactorTypeTranslationService
+     */
+    private $translator;
+
+    public function __construct(SecondFactorTypeTranslationService $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function getName()
+    {
+        return 'ra.twig.second_factor_type';
+    }
+
+    public function getFilters()
+    {
+        return [
+            new Twig_SimpleFilter('trans_second_factor_type', [$this, 'translateSecondFactorType']),
+        ];
+    }
+
+    public function translateSecondFactorType($secondFactorType)
+    {
+        return $this->translator->translate($secondFactorType, 'ss.second_factor.type.%s');
+    }
+}


### PR DESCRIPTION
Remove the hard tiqr and biometric references from the translation file and provide a means to translate the token name in the front end.

The solution was based on a very similar problem solved in [RA](https://github.com/OpenConext/Stepup-RA/pull/149).

