### PR TITLE
Show a single token test button

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-29T11:52:53Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-04-03T12:41:04Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -464,12 +464,12 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
         <source>ss.second_factor.revoke.button.revoke</source>
         <target>Remove</target>
-        <jms:reference-file line="55">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d18b6bcd8642fedf8e5371cb722efc604e8281" resname="ss.second_factor.revoke.button.test">
         <source>ss.second_factor.revoke.button.test</source>
-        <target>Test</target>
-        <jms:reference-file line="51">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <target>Test a token</target>
+        <jms:reference-file line="62">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8cb0dc5d3faca805d69dce7496307078d2234dfb" resname="ss.second_factor.revoke.second_factor_type.sms">
         <source>ss.second_factor.revoke.second_factor_type.sms</source>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-29T11:52:47Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-04-03T12:41:01Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -462,12 +462,12 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
         <source>ss.second_factor.revoke.button.revoke</source>
         <target>Verwijderen</target>
-        <jms:reference-file line="55">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d18b6bcd8642fedf8e5371cb722efc604e8281" resname="ss.second_factor.revoke.button.test">
         <source>ss.second_factor.revoke.button.test</source>
-        <target>Testen</target>
-        <jms:reference-file line="51">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <target>Test een token</target>
+        <jms:reference-file line="62">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8cb0dc5d3faca805d69dce7496307078d2234dfb" resname="ss.second_factor.revoke.second_factor_type.sms">
         <source>ss.second_factor.revoke.second_factor_type.sms</source>

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
@@ -9,7 +9,7 @@ ss_second_factor_list:
     defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:SecondFactor:list }
 
 ss_second_factor_test:
-    path:     /second-factor/{secondFactorId}/test
+    path:     /second-factor/test
     methods:  [GET]
     defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:Saml:testSecondFactor }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -45,11 +45,6 @@
                             <td>{{ secondFactor.secondFactorIdentifier }}</td>
                             <td>
                                 <div class="btn-group pull-right" role="group">
-                                    {% if state == 'vetted' %}
-                                        <a class="btn btn-mini btn-default"
-                                            href="{{ path('ss_second_factor_test', {'secondFactorId': secondFactor.id}) }}">
-                                            {{ 'ss.second_factor.revoke.button.test'|trans }}</a>
-                                    {% endif %}
                                     <a class="btn btn-mini btn-warning"
                                         href="{{ path('ss_second_factor_revoke', {'state': state, 'secondFactorId': secondFactor.id}) }}">
                                         {{ 'ss.second_factor.revoke.button.revoke'|trans }}
@@ -59,6 +54,17 @@
                         </tr>
                     {% endfor %}
                     </tbody>
+                    {% if state == 'vetted' %}
+                    <tfoot>
+                        <tr>
+                            <td colspan="3">
+                                <a class="btn btn-mini btn-default pull-right" href="{{ path('ss_second_factor_test') }}">
+                                    {{ 'ss.second_factor.revoke.button.test'|trans }}
+                                </a>
+                            </td>
+                        </tr>
+                    </tfoot>
+                    {% endif %}
                 </table>
             </div>
         </div>


### PR DESCRIPTION
* The test endpoint was changed to no longer test a specified token type.
* To ascertain the user is allowed to use the token test endpoint, a new second factor service method was added. Testing if the user has a vetted LoA >= 2 token.
* The test button is placed in the footer of the vetted tokens table.

Details and a screenshot can be found in:
https://www.pivotaltracker.com/story/show/154476963