### PR TITLE
Show expiration date in the token overview

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -533,7 +533,7 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       </trans-unit>
       <trans-unit id="1d6751b490158de0a89683522c6ba1a8b957875c" resname="ss.second_factor_list.header.expired_warning">
         <source>ss.second_factor_list.header.expired_warning</source>
-        <target>Expired!</target>
+        <target>Expired</target>
         <jms:reference-file line="53">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fedd12f3e661692730a3650ef6db64e71c9d8441" resname="ss.second_factor_list.header.second_factor_identifier">

--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-04-03T12:41:04Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-04-06T13:30:38Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -464,12 +464,12 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
         <source>ss.second_factor.revoke.button.revoke</source>
         <target>Remove</target>
-        <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="61">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d18b6bcd8642fedf8e5371cb722efc604e8281" resname="ss.second_factor.revoke.button.test">
         <source>ss.second_factor.revoke.button.test</source>
         <target>Test a token</target>
-        <jms:reference-file line="62">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="73">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8cb0dc5d3faca805d69dce7496307078d2234dfb" resname="ss.second_factor.revoke.second_factor_type.sms">
         <source>ss.second_factor.revoke.second_factor_type.sms</source>
@@ -521,15 +521,30 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
         <target>YubiKey</target>
         <jms:reference-file line="36">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="86cc7496d68c0c83cd166ad3e22ed89b47b1c989" resname="ss.second_factor_list.header.expiration_date">
+        <source>ss.second_factor_list.header.expiration_date</source>
+        <target>Expiration date</target>
+        <jms:reference-file line="39">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="de7df14a4a009c74319576cad9e6c6e68e89ac0c" resname="ss.second_factor_list.header.expired_explanation">
+        <source>ss.second_factor_list.header.expired_explanation</source>
+        <target>The token registration period has expired. Please remove your token and restart the registration process.</target>
+        <jms:reference-file line="82">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="1d6751b490158de0a89683522c6ba1a8b957875c" resname="ss.second_factor_list.header.expired_warning">
+        <source>ss.second_factor_list.header.expired_warning</source>
+        <target>Expired!</target>
+        <jms:reference-file line="53">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="fedd12f3e661692730a3650ef6db64e71c9d8441" resname="ss.second_factor_list.header.second_factor_identifier">
         <source>ss.second_factor_list.header.second_factor_identifier</source>
         <target>ID</target>
-        <jms:reference-file line="37">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e4d199fd46ed7fa1c78a8fde6faef80f034cd662" resname="ss.second_factor_list.header.type">
         <source>ss.second_factor_list.header.type</source>
         <target>Token</target>
-        <jms:reference-file line="36">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb5cac733dfdfe5c5e6818dee7d71aea02e95aa4" resname="ss.security.session_expired.click_to_login">
         <source>ss.security.session_expired.click_to_login</source>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-04-03T12:41:01Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-04-06T13:30:34Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -462,12 +462,12 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="39bf5f5849cef0ac9b176c769c79169676fc7b96" resname="ss.second_factor.revoke.button.revoke">
         <source>ss.second_factor.revoke.button.revoke</source>
         <target>Verwijderen</target>
-        <jms:reference-file line="50">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="61">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d18b6bcd8642fedf8e5371cb722efc604e8281" resname="ss.second_factor.revoke.button.test">
         <source>ss.second_factor.revoke.button.test</source>
         <target>Test een token</target>
-        <jms:reference-file line="62">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="73">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8cb0dc5d3faca805d69dce7496307078d2234dfb" resname="ss.second_factor.revoke.second_factor_type.sms">
         <source>ss.second_factor.revoke.second_factor_type.sms</source>
@@ -519,15 +519,30 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
         <target>YubiKey</target>
         <jms:reference-file line="36">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="86cc7496d68c0c83cd166ad3e22ed89b47b1c989" resname="ss.second_factor_list.header.expiration_date">
+        <source>ss.second_factor_list.header.expiration_date</source>
+        <target>Verloopdatum</target>
+        <jms:reference-file line="39">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="de7df14a4a009c74319576cad9e6c6e68e89ac0c" resname="ss.second_factor_list.header.expired_explanation">
+        <source>ss.second_factor_list.header.expired_explanation</source>
+        <target>De uiterste registratiedatum is verlopen. Registreer het token opnieuw door deze te verwijderen en het registratieproces opnieuw te starten.</target>
+        <jms:reference-file line="82">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="1d6751b490158de0a89683522c6ba1a8b957875c" resname="ss.second_factor_list.header.expired_warning">
+        <source>ss.second_factor_list.header.expired_warning</source>
+        <target>Verlopen!</target>
+        <jms:reference-file line="53">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="fedd12f3e661692730a3650ef6db64e71c9d8441" resname="ss.second_factor_list.header.second_factor_identifier">
         <source>ss.second_factor_list.header.second_factor_identifier</source>
         <target>ID</target>
-        <jms:reference-file line="37">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e4d199fd46ed7fa1c78a8fde6faef80f034cd662" resname="ss.second_factor_list.header.type">
         <source>ss.second_factor_list.header.type</source>
         <target>Token</target>
-        <jms:reference-file line="36">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb5cac733dfdfe5c5e6818dee7d71aea02e95aa4" resname="ss.security.session_expired.click_to_login">
         <source>ss.security.session_expired.click_to_login</source>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -531,7 +531,7 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       </trans-unit>
       <trans-unit id="1d6751b490158de0a89683522c6ba1a8b957875c" resname="ss.second_factor_list.header.expired_warning">
         <source>ss.second_factor_list.header.expired_warning</source>
-        <target>Verlopen!</target>
+        <target>Verlopen</target>
         <jms:reference-file line="53">/../src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fedd12f3e661692730a3650ef6db64e71c9d8441" resname="ss.second_factor_list.header.second_factor_identifier">

--- a/composer.lock
+++ b/composer.lock
@@ -2091,16 +2091,16 @@
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "3.4.0",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-bundle.git",
-                "reference": "e0afaa26ffd0a38bb89b55e95761fe9555b6670f"
+                "reference": "2542a5f0d3032bc8c995b995dcc029999007393f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/e0afaa26ffd0a38bb89b55e95761fe9555b6670f",
-                "reference": "e0afaa26ffd0a38bb89b55e95761fe9555b6670f",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/2542a5f0d3032bc8c995b995dcc029999007393f",
+                "reference": "2542a5f0d3032bc8c995b995dcc029999007393f",
                 "shasum": ""
             },
             "require": {
@@ -2143,7 +2143,7 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2018-04-09T11:13:53+00:00"
+            "time": "2018-04-12T14:02:19+00:00"
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
@@ -41,6 +41,8 @@ class SecondFactorController extends Controller
         // Get all available second factors from the config.
         $allSecondFactors = $this->getParameter('ss.enabled_second_factors');
 
+        $expirationHelper = $this->get('surfnet_stepup.registration_expiration_helper');
+
         $secondFactors = $service->getSecondFactorsForIdentity(
             $identity,
             $allSecondFactors,
@@ -56,6 +58,7 @@ class SecondFactorController extends Controller
             'verifiedSecondFactors' => $secondFactors->verified,
             'vettedSecondFactors' => $secondFactors->vetted,
             'availableSecondFactors' => $secondFactors->available,
+            'expirationHelper' => $expirationHelper,
         ];
     }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
@@ -114,6 +114,16 @@ select[name="stepup_switch_locale[locale]"] {
     margin-top: 2em;
 }
 
+.table-striped tbody td {
+    vertical-align: middle !important;
+}
+
+span.label {
+    display: inline-block;
+    line-height: 2em;
+    padding: .2em .6em .1em;
+}
+
 @media print {
     footer,
     .page-header-user,

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
@@ -110,6 +110,9 @@ select[name="stepup_switch_locale[locale]"] {
         margin-right: 5px;
     }
 }
+.m-t-2 {
+    margin-top: 2em;
+}
 
 @media print {
     footer,

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -6,9 +6,9 @@
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-    {{ macro.secondFactorTable(vettedSecondFactors, 'ss.second_factor.list.text.vetted', 'vetted', email) }}
-    {{ macro.secondFactorTable(verifiedSecondFactors, 'ss.second_factor.list.text.verified', 'verified', email) }}
-    {{ macro.secondFactorTable(unverifiedSecondFactors, 'ss.second_factor.list.text.unverified', 'unverified', email) }}
+    {{ macro.secondFactorTable(vettedSecondFactors, 'ss.second_factor.list.text.vetted', 'vetted', email, expirationHelper) }}
+    {{ macro.secondFactorTable(verifiedSecondFactors, 'ss.second_factor.list.text.verified', 'verified', email, expirationHelper) }}
+    {{ macro.secondFactorTable(unverifiedSecondFactors, 'ss.second_factor.list.text.unverified', 'unverified', email, expirationHelper) }}
 
     {% if registrationsLeft > 0
             and ((unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty)
@@ -18,15 +18,16 @@
             <p>{{ 'ss.second_factor.list.text.no_second_factors'|trans }}</p>
         {% endif %}
             <a href="{{ path('ss_registration_display_types') }}"
-               class="btn btn-primary">
+               class="btn btn-primary m-t-2">
                 {{ 'ss.second_factor.list.button.register_second_factor'|trans }}
             </a>
     {% endif %}
 
 {% endblock %}
 
-{% macro secondFactorTable(secondFactorCollection, text, state, email) %}
+{% macro secondFactorTable(secondFactorCollection, text, state, email, expirationHelper, locale) %}
     {% if secondFactorCollection.elements is not empty %}
+        {% set hasExpired = false %}
         <p>{{ text|trans({'%email%': email}) }}</p>
         <div class="row">
             <div class="col-xs-12">
@@ -35,6 +36,9 @@
                     <tr>
                         <th scope="col">{{ 'ss.second_factor_list.header.type'|trans }}</th>
                         <th scope="col">{{ 'ss.second_factor_list.header.second_factor_identifier'|trans }}</th>
+                        {% if state == 'verified' %}
+                            <th scope="col">{{ 'ss.second_factor_list.header.expiration_date'|trans }}</th>
+                        {% endif %}
                         <th scope="col">{# Action button #}</th>
                     </tr>
                     </thead>
@@ -43,6 +47,15 @@
                         <tr>
                             <td>{{ secondFactor.type|trans_second_factor_type }}</td>
                             <td>{{ secondFactor.secondFactorIdentifier }}</td>
+                            {% if state == 'verified' %}
+                            <td>
+                                {{ expirationHelper.expiresAt(secondFactor.registrationRequestedAt)|localizeddate('full', 'none', locale) }}
+                                {% if expirationHelper.hasExpired(secondFactor.registrationRequestedAt) %}
+                                    {% set hasExpired = true %}
+                                    <span class="label label-danger">{{ 'ss.second_factor_list.header.expired_warning'|trans }}</span>
+                                {% endif %}
+                            </td>
+                            {% endif %}
                             <td>
                                 <div class="btn-group pull-right" role="group">
                                     <a class="btn btn-mini btn-warning"
@@ -57,7 +70,7 @@
                     {% if state == 'vetted' %}
                     <tfoot>
                         <tr>
-                            <td colspan="3">
+                            <td colspan="4">
                                 <a class="btn btn-mini btn-default pull-right" href="{{ path('ss_second_factor_test') }}">
                                     {{ 'ss.second_factor.revoke.button.test'|trans }}
                                 </a>
@@ -66,6 +79,10 @@
                     </tfoot>
                     {% endif %}
                 </table>
+
+                {% if hasExpired %}
+                    <p><span class="label label-danger">{{ 'ss.second_factor_list.header.expired_warning'|trans }}</span> {{ 'ss.second_factor_list.header.expired_explanation'|trans }}
+                {% endif %}
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
The expiration date is only shown on the verified tokens. When the expiration date is met, a label and explanation is added to instruct the user how to restart the registration of his token.

Todo:
 - [x] Install Stepup-bundle update 3.4.1
 - [x] Fix alignment issue with label 