### PR TITLE
Redirect after POST when returning from GSSP

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/GssfController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/GssfController.php
@@ -35,6 +35,17 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 final class GssfController extends Controller
 {
     /**
+     * Render the initiation form.
+     *
+     * This action has two parameters:
+     *
+     * - authenticationFailed (default false), will trigger an error message
+     *   and is used when a SAML failure response was received, for example
+     *   when the users cancelled the registration
+     *
+     * - proofOfPossessionFailed (default false), will trigger an error message
+     *   when possession was not proven, but the SAML response was successful
+     *
      * @param Request $request
      * @param string $provider
      * @return array|Response

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
@@ -63,7 +63,10 @@ ss_registration_sms_prove_possession:
 ss_registration_gssf_initiate:
     path:     /registration/gssf/{provider}/initiate
     methods:  [GET]
-    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:Registration/Gssf:initiate }
+    defaults:
+        _controller: SurfnetStepupSelfServiceSelfServiceBundle:Registration/Gssf:initiate
+        authenticationFailed: false
+        proofOfPossessionFailed: false
 
 ss_registration_gssf_authenticate:
     path:     /registration/gssf/{provider}/authenticate

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/Gssf/initiate.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/Gssf/initiate.html.twig
@@ -19,10 +19,10 @@
 
     <hr>
 
-    {% if authenticationFailed is defined %}
+    {% if authenticationFailed == true %}
         <div class="alert alert-danger">{{ secondFactorConfig.getAuthnFailed() }}</div>
     {% endif %}
-    {% if proofOfPossessionFailed is defined %}
+    {% if proofOfPossessionFailed == true %}
         <div class="alert alert-danger">{{ secondFactorConfig.getPopFailed() }}</div>
     {% endif %}
     {{ form(form) }}


### PR DESCRIPTION
The ACS location of GSSP should never show a page without first
redirecting. This way, the user can refresh the page or change the
language before trying again.

See: https://www.pivotaltracker.com/story/show/157843953