### PR TITLE
Use flash messages for error messaging

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/SmsController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/SmsController.php
@@ -51,15 +51,14 @@ class SmsController extends Controller
             $command->institution = $identity->institution;
 
             if ($otpRequestsRemaining === 0) {
-                $form->addError(new FormError('ss.prove_phone_possession.challenge_request_limit_reached'));
-
+                $this->addFlash('error', 'ss.prove_phone_possession.challenge_request_limit_reached');
                 return array_merge(['form' => $form->createView()], $viewVariables);
             }
 
             if ($service->sendChallenge($command)) {
                 return $this->redirect($this->generateUrl('ss_registration_sms_prove_possession'));
             } else {
-                $form->addError(new FormError('ss.prove_phone_possession.send_sms_challenge_failed'));
+                $this->addFlash('error', 'ss.prove_phone_possession.send_sms_challenge_failed');
             }
         }
 
@@ -115,13 +114,13 @@ class SmsController extends Controller
                     );
                 }
             } elseif ($result->wasIncorrectChallengeResponseGiven()) {
-                $form->addError(new FormError('ss.prove_phone_possession.incorrect_challenge_response'));
+                $this->addFlash('error', 'ss.prove_phone_possession.incorrect_challenge_response');
             } elseif ($result->hasChallengeExpired()) {
-                $form->addError(new FormError('ss.prove_phone_possession.challenge_expired'));
+                $this->addFlash('error', 'ss.prove_phone_possession.challenge_expired');
             } elseif ($result->wereTooManyAttemptsMade()) {
-                $form->addError(new FormError('ss.prove_phone_possession.too_many_attempts'));
+                $this->addFlash('error', 'ss.prove_phone_possession.too_many_attempts');
             } else {
-                $form->addError(new FormError('ss.prove_phone_possession.proof_of_possession_failed'));
+                $this->addFlash('error', 'ss.prove_phone_possession.proof_of_possession_failed');
             }
         }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/YubikeyController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/YubikeyController.php
@@ -60,11 +60,11 @@ class YubikeyController extends Controller
                     );
                 }
             } elseif ($result->isOtpInvalid()) {
-                $form->get('otp')->addError(new FormError('ss.verify_yubikey_command.otp.otp_invalid'));
+                $this->addFlash('error', 'ss.verify_yubikey_command.otp.otp_invalid');
             } elseif ($result->didOtpVerificationFail()) {
-                $form->get('otp')->addError(new FormError('ss.verify_yubikey_command.otp.verification_error'));
+                $this->addFlash('error', 'ss.verify_yubikey_command.otp.verification_error');
             } else {
-                $form->addError(new FormError('ss.prove_yubikey_possession.proof_of_possession_failed'));
+                $this->addFlash('error', 'ss.prove_yubikey_possession.proof_of_possession_failed');
             }
         }
 


### PR DESCRIPTION
The addError construction expects translated messages. The translator
is not available in the controllers and adding extra coupling was
not preferred over changing to flash messages.

See: https://www.pivotaltracker.com/story/show/160228972