### PR TITLE
Prevent form loading issue

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/SmsController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/SmsController.php
@@ -23,8 +23,8 @@ use Surfnet\StepupSelfService\SelfServiceBundle\Command\SendSmsChallengeCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\VerifySmsChallengeCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Controller\Controller;
 use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\SendSmsChallengeType;
+use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\VerifySmsChallengeType;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsSecondFactorService;
-use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 
 class SmsController extends Controller
@@ -95,7 +95,7 @@ class SmsController extends Controller
         $command = new VerifySmsChallengeCommand();
         $command->identity = $identity->id;
 
-        $form = $this->createForm('ss_verify_sms_challenge', $command)->handleRequest($request);
+        $form = $this->createForm(VerifySmsChallengeType::class, $command)->handleRequest($request);
 
         if ($form->isValid()) {
             $result = $service->provePossession($command);

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/U2fController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/U2fController.php
@@ -82,7 +82,7 @@ class U2fController extends Controller
 
         $form = $this
             ->createForm(
-                'surfnet_stepup_u2f_register_device',
+                RegisterDeviceType::class,
                 $registerResponse,
                 [
                     'register_request' => $registerRequest,

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\RevokeCommand;
+use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\RevokeSecondFactorType;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SecondFactorService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -109,7 +110,7 @@ class SecondFactorController extends Controller
         $command->identity = $identity;
         $command->secondFactor = $secondFactor;
 
-        $form = $this->createForm('ss_revoke_second_factor', $command)->handleRequest($request);
+        $form = $this->createForm(RevokeSecondFactorType::class, $command)->handleRequest($request);
 
         if ($form->isValid()) {
             /** @var FlashBagInterface $flashBag */


### PR DESCRIPTION
The feature in Symfony 2 where forms where created by referencing them
by their name (ss_verify_sms_challenge) no longer works in Symfony 3.
This commit fixes this by referencing the form by it's FQDN
(VerifySmsChallengeType).

In the previous Symfony 3.4 compatibility PR, a lot of these fixes have
been done for other Types. This one was overlooked.

See: https://www.pivotaltracker.com/story/show/160473876