### PR TITLE
Be compatible with recent MW client bundle change

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -184,6 +184,8 @@ class SecondFactorService
         $query = new VerifiedSecondFactorSearchQuery();
         $query->setIdentityId($identityId);
         $query->setActorInstitution($actorInstitution);
+        // Actor and identity are equal in SelfService.
+        $query->setActorId($identityId);
         return $this->secondFactors->searchVerified($query);
     }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -184,6 +184,7 @@ class SecondFactorService
         $query = new VerifiedSecondFactorSearchQuery();
         $query->setIdentityId($identityId);
         $query->setActorInstitution($actorInstitution);
+        $query->setInstitution($actorInstitution);
         // Actor and identity are equal in SelfService.
         $query->setActorId($identityId);
         return $this->secondFactors->searchVerified($query);


### PR DESCRIPTION
The VerifiedSecondFactorSearchQuery requires an actor id. The id of the
identity is used for this.