### PR TITLE
Set actor id on the verified second factor query

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -183,6 +183,8 @@ class SecondFactorService
     {
         $query = new VerifiedSecondFactorSearchQuery();
         $query->setIdentityId($identityId);
+        // In self service the actor equals the identity of the user.
+        $query->setActorId($identityId);
         $query->setActorInstitution($actorInstitution);
         return $this->secondFactors->searchVerified($query);
     }


### PR DESCRIPTION
The is a requirement set in the middleware API, used for RA management
related actions. We just pass the users identity id as the actor id.
Which is the correct behavior.