### PR TITLE
Set institution with setter

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/IdentityService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/IdentityService.php
@@ -108,8 +108,9 @@ class IdentityService implements UserProviderInterface
      */
     public function findByNameIdAndInstitution($nameId, $institution)
     {
-        $searchQuery = new IdentitySearchQuery($institution);
+        $searchQuery = new IdentitySearchQuery();
         $searchQuery->setNameId($nameId);
+        $searchQuery->setInstitution($institution);
 
         try {
             $result = $this->apiIdentityService->search($searchQuery);


### PR DESCRIPTION
The constructor argument was removed from the IdentitySearchQuery as the institution is no longer a required param.

**Relates to**: 
https://github.com/OpenConext/Stepup-Middleware-clientbundle/pull/72
https://github.com/OpenConext/Stepup-Middleware/pull/255
https://github.com/OpenConext/Stepup-RA/pull/183