### PR TITLE
Fix mpdf relative url's and logging

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -13,6 +13,9 @@
     <link href="{{ asset_url }}" type="text/css" rel="stylesheet" media="screen, print" />
     {% endstylesheets %}
 {% endblock head_style %}
+{% block head_bottom %}
+    <base href="{{ app.request.schemeAndHttpHost ~ app.request.baseUrl }}">
+{% endblock head_bottom %}
 
 {% block navbar %}
     {#{{ mopa_bootstrap_navbar('frontendNavbar') }}#}


### PR DESCRIPTION
Relative url's weren't supported, because mpdf was trying to get it by
hostname in the request. If however a proxy should update the hostname
it wouldn't work. Therefore the `base` html tag was added which was
supported by mpdf for resolving absolute urls. Also the
logging was added and decent symfony shutdown.