### PR TITLE
Fix art for authentication

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/IdentityService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/IdentityService.php
@@ -199,7 +199,7 @@ class IdentityService implements UserProviderInterface
      */
     public function processCommand($command)
     {
-        $messageTemplate = 'Exception when saving Identity[%s]: with command "%s", error: "%s"';
+        $messageTemplate = 'Exception when saving Identity "%s": with command "%s", error: "%s"';
 
         try {
             $result = $this->commandService->execute($command);


### PR DESCRIPTION
This will fix the art for exceptions when authenticating. The art
was based on the users UUID but should be generated per exception type
and should not be unique per user.