### PR TITLE
Find verified second factors without authorization context

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2346,16 +2346,16 @@
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",
-            "version": "3.0.7",
+            "version": "3.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
-                "reference": "88c2b05395d2dbd8cf16f0acb74509f9fcb0c3ce"
+                "reference": "ab6f166965fa6cc8467034275f28db621e84885a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/88c2b05395d2dbd8cf16f0acb74509f9fcb0c3ce",
-                "reference": "88c2b05395d2dbd8cf16f0acb74509f9fcb0c3ce",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/ab6f166965fa6cc8467034275f28db621e84885a",
+                "reference": "ab6f166965fa6cc8467034275f28db621e84885a",
                 "shasum": ""
             },
             "require": {
@@ -2366,10 +2366,11 @@
                 "psr/log": "~1.0",
                 "ramsey/uuid": "^3.4",
                 "surfnet/stepup-bundle": "^4.0",
-                "symfony/config": ">=2.7,<4",
-                "symfony/dependency-injection": ">=2.7,<4",
-                "symfony/http-kernel": ">=2.7,<4",
-                "symfony/validator": ">=2.7,<4"
+                "symfony/config": "^2.7|^2.8|^3.4",
+                "symfony/dependency-injection": "^2.7|^2.8|^3.4",
+                "symfony/framework-bundle": "^2.7|^2.8|^3.4",
+                "symfony/http-kernel": "^2.7|^2.8|^3.4",
+                "symfony/validator": "^2.7|^2.8|^3.4"
             },
             "conflict": {
                 "surfnet/stepup-middleware-client": "*"
@@ -2395,7 +2396,7 @@
                 "Apache-2.0"
             ],
             "description": "Symfony2 bundle for consuming the Step-up Middleware API.",
-            "time": "2019-02-14T14:10:00+00:00"
+            "time": "2019-05-07T11:18:24+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -5011,16 +5011,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.4.21",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "5dab0d4b2ac99ab22b447b615fdfdc10ec4af3d5"
+                "reference": "a43a2f6c465a2d99635fea0addbebddc3864ad97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/5dab0d4b2ac99ab22b447b615fdfdc10ec4af3d5",
-                "reference": "5dab0d4b2ac99ab22b447b615fdfdc10ec4af3d5",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/a43a2f6c465a2d99635fea0addbebddc3864ad97",
+                "reference": "a43a2f6c465a2d99635fea0addbebddc3864ad97",
                 "shasum": ""
             },
             "require": {
@@ -5030,7 +5030,6 @@
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "suggest": {
-                "ext-zip": "Zip support is required when using bin/simple-phpunit",
                 "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
             },
             "bin": [
@@ -5073,7 +5072,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2019-01-01T13:45:19+00:00"
+            "time": "2019-04-16T09:03:16+00:00"
         },
         {
             "name": "theseer/fdomdocument",

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -19,7 +19,7 @@
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Service;
 
 use Surfnet\StepupMiddlewareClient\Identity\Dto\UnverifiedSecondFactorSearchQuery;
-use Surfnet\StepupMiddlewareClient\Identity\Dto\VerifiedSecondFactorSearchQuery;
+use Surfnet\StepupMiddlewareClient\Identity\Dto\VerifiedSecondFactorOfIdentitySearchQuery;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\VettedSecondFactorSearchQuery;
 use Surfnet\StepupMiddlewareClientBundle\Dto\CollectionDto;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Command\RevokeOwnSecondFactorCommand;
@@ -181,7 +181,7 @@ class SecondFactorService
      */
     public function findVerifiedByIdentity($identityId, $actorInstitution)
     {
-        $query = new VerifiedSecondFactorSearchQuery();
+        $query = new VerifiedSecondFactorOfIdentitySearchQuery();
         $query->setIdentityId($identityId);
         return $this->secondFactors->searchOwnVerified($query);
     }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -183,13 +183,7 @@ class SecondFactorService
     {
         $query = new VerifiedSecondFactorSearchQuery();
         $query->setIdentityId($identityId);
-        // In self service the actor equals the identity of the user.
-        $query->setActorId($identityId);
-        $query->setActorInstitution($actorInstitution);
-        $query->setInstitution($actorInstitution);
-        // Actor and identity are equal in SelfService.
-        $query->setActorId($identityId);
-        return $this->secondFactors->searchVerified($query);
+        return $this->secondFactors->searchOwnVerified($query);
     }
 
     /**


### PR DESCRIPTION
The authorization context that was added for the RA application applies
an authorization context to the query. This filters out results that not
match the context of the current RA state (the institution that is
currently active).

For Self Service we do not want to apply that context based filtering.

See: https://www.pivotaltracker.com/story/show/165740432
See: https://github.com/OpenConext/Stepup-Middleware/pull/279
See: https://github.com/OpenConext/Stepup-Middleware-clientbundle/pull/82