### PR TITLE
Remove the actorInstitution

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "2bb70d27e1f4aa52aa09d6d53fd6ac05",
@@ -2346,16 +2346,16 @@
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",
-            "version": "3.0.16",
+            "version": "3.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
-                "reference": "ab6f166965fa6cc8467034275f28db621e84885a"
+                "reference": "2a3f609a90370bc68ae49e827270dcc6411709d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/ab6f166965fa6cc8467034275f28db621e84885a",
-                "reference": "ab6f166965fa6cc8467034275f28db621e84885a",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/2a3f609a90370bc68ae49e827270dcc6411709d6",
+                "reference": "2a3f609a90370bc68ae49e827270dcc6411709d6",
                 "shasum": ""
             },
             "require": {
@@ -2396,7 +2396,7 @@
                 "Apache-2.0"
             ],
             "description": "Symfony2 bundle for consuming the Step-up Middleware API.",
-            "time": "2019-05-07T11:18:24+00:00"
+            "time": "2019-05-09T13:24:49+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/EntryPointController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/EntryPointController.php
@@ -25,12 +25,11 @@ class EntryPointController extends Controller
     public function decideSecondFactorFlowAction()
     {
         $identity = $this->getIdentity();
-        $institution = $identity->institution;
 
         /** @var SecondFactorService $service */
         $service = $this->get('surfnet_stepup_self_service_self_service.service.second_factor');
 
-        if ($service->doSecondFactorsExistForIdentity($identity->id, $institution)) {
+        if ($service->doSecondFactorsExistForIdentity($identity->id)) {
             return $this->redirect($this->generateUrl('ss_second_factor_list'));
         } else {
             return $this->redirect(

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
@@ -22,6 +22,8 @@ use DateInterval;
 use Mpdf\Mpdf;
 use Mpdf\Output\Destination as MpdfDestination;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RaLocationService;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RaService;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SecondFactorService;
 use Surfnet\StepupSelfService\SelfServiceBundle\Value\AvailableTokenCollection;
 use Symfony\Component\HttpFoundation\Request;
@@ -51,7 +53,6 @@ class RegistrationController extends Controller
 
         $secondFactors = $service->getSecondFactorsForIdentity(
             $identity,
-            $institution,
             $allSecondFactors,
             $institutionConfigurationOptions->allowedSecondFactors,
             $institutionConfigurationOptions->numberOfTokensPerIdentity
@@ -200,7 +201,9 @@ class RegistrationController extends Controller
             'verifyEmail'      => $this->emailVerificationIsRequired(),
         ];
 
+        /** @var RaService $raService */
         $raService         = $this->get('self_service.service.ra');
+        /** @var RaLocationService $raLocationService */
         $raLocationService = $this->get('self_service.service.ra_location');
 
         $institutionConfigurationOptions = $this->get('self_service.service.institution_configuration_options')

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
@@ -47,7 +47,6 @@ class SecondFactorController extends Controller
 
         $secondFactors = $service->getSecondFactorsForIdentity(
             $identity,
-            $institution,
             $allSecondFactors,
             $institutionConfigurationOptions->allowedSecondFactors,
             $institutionConfigurationOptions->numberOfTokensPerIdentity
@@ -75,11 +74,10 @@ class SecondFactorController extends Controller
     public function revokeAction(Request $request, $state, $secondFactorId)
     {
         $identity = $this->getIdentity();
-        $institution = $identity->institution;
 
         /** @var SecondFactorService $service */
         $service = $this->get('surfnet_stepup_self_service_self_service.service.second_factor');
-        if (!$service->identityHasSecondFactorOfStateWithId($identity->id, $state, $secondFactorId, $institution)) {
+        if (!$service->identityHasSecondFactorOfStateWithId($identity->id, $state, $secondFactorId)) {
             $this->get('logger')->error(sprintf(
                 'Identity "%s" tried to revoke "%s" second factor "%s", but does not own that second factor',
                 $identity->id,

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -116,13 +116,12 @@ class SecondFactorService
      * is irrelevant.
      *
      * @param string $identityId
-     * @param string $institution
      * @return bool
      */
-    public function doSecondFactorsExistForIdentity($identityId, $institution)
+    public function doSecondFactorsExistForIdentity($identityId)
     {
         $unverifiedSecondFactors = $this->findUnverifiedByIdentity($identityId);
-        $verifiedSecondFactors = $this->findVerifiedByIdentity($identityId, $institution);
+        $verifiedSecondFactors = $this->findVerifiedByIdentity($identityId);
         $vettedSecondFactors = $this->findVettedByIdentity($identityId);
 
         return $unverifiedSecondFactors->getTotalItems() +
@@ -130,14 +129,14 @@ class SecondFactorService
                $vettedSecondFactors->getTotalItems() > 0;
     }
 
-    public function identityHasSecondFactorOfStateWithId($identityId, $state, $secondFactorId, $institution)
+    public function identityHasSecondFactorOfStateWithId($identityId, $state, $secondFactorId)
     {
         switch ($state) {
             case 'unverified':
                 $secondFactors = $this->findUnverifiedByIdentity($identityId);
                 break;
             case 'verified':
-                $secondFactors = $this->findVerifiedByIdentity($identityId, $institution);
+                $secondFactors = $this->findVerifiedByIdentity($identityId);
                 break;
             case 'vetted':
                 $secondFactors = $this->findVettedByIdentity($identityId);
@@ -176,10 +175,9 @@ class SecondFactorService
      * Returns the given registrant's verified second factors.
      *
      * @param string $identityId
-     * @param string $actorInstitution
      * @return VerifiedSecondFactorCollection
      */
-    public function findVerifiedByIdentity($identityId, $actorInstitution)
+    public function findVerifiedByIdentity($identityId)
     {
         $query = new VerifiedSecondFactorOfIdentitySearchQuery();
         $query->setIdentityId($identityId);
@@ -288,7 +286,6 @@ class SecondFactorService
 
     /**
      * @param $identity
-     * @param string $institution
      * @param $allSecondFactors
      * @param $allowedSecondFactors
      * @param $maximumNumberOfRegistrations
@@ -296,13 +293,12 @@ class SecondFactorService
      */
     public function getSecondFactorsForIdentity(
         $identity,
-        $institution,
         $allSecondFactors,
         $allowedSecondFactors,
         $maximumNumberOfRegistrations
     ) {
         $unverified = $this->findUnverifiedByIdentity($identity->id);
-        $verified = $this->findVerifiedByIdentity($identity->id, $institution);
+        $verified = $this->findVerifiedByIdentity($identity->id);
         $vetted = $this->findVettedByIdentity($identity->id);
         // Determine which Second Factors are still available for registration.
         $available = $this->determineAvailable($allSecondFactors, $unverified, $verified, $vetted);


### PR DESCRIPTION
The actorInstitution was removed. this is possible because the SRAA (institution) switcher is removed as it is no longer useful after the FGA changes. This because earlier all overviews where from the viewpoint of an institution but now it's from a registration authority. 

These changes are needed to reflect the changes in RA and Middleware.