### PR TITLE
Fix RV acceptance tests in Travis

### DIFF
--- a/app/Resources/views/dev/mock-acs.html.twig
+++ b/app/Resources/views/dev/mock-acs.html.twig
@@ -1,6 +1,6 @@
 <html>
     <h2>Select response</h2>
-    <form method="post" action="">
+    <form method="post" action="{{ action }}">
 
         <h3>Attributes</h3>
         <textarea name="attributes" style="width:800px; height: 500px;">

--- a/app/config/remote_vetting.yml
+++ b/app/config/remote_vetting.yml
@@ -83,12 +83,14 @@ services:
     $logger: '@logger'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService:
+    public: true
     arguments:
       $remoteVettingContext: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\RemoteVettingContext'
       $identityEncrypter: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Encryption\IdentityEncrypter'
       $logger: '@logger'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Controller\RemoteVettingController:
+    public: true
     arguments:
       - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService'
       - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\RemoteVettingViewHelper'
@@ -103,6 +105,7 @@ services:
       $publicCertPath: '%saml_rv_publickey%'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Mock\RemoteVetting\MockRemoteVetController:
+    public: true
     arguments:
       - '@Surfnet\StepupSelfService\SelfServiceBundle\Mock\RemoteVetting\MockGateway'
       - '@twig'

--- a/app/config/remote_vetting.yml
+++ b/app/config/remote_vetting.yml
@@ -37,24 +37,24 @@ parameters:
 
   identity_encryption_configuration:
     encryption_public_key: |
-        -----BEGIN CERTIFICATE-----
-        MIIC6jCCAdICCQC9cRx5wiwWOjANBgkqhkiG9w0BAQsFADA3MRwwGgYDVQQDDBNT
-        ZWxmU2VydmljZSBTQU1MIFNQMRcwFQYDVQQKDA5EZXZlbG9wbWVudCBWTTAeFw0x
-        ODA3MzAxMjMwNDdaFw0yMzA3MjkxMjMwNDdaMDcxHDAaBgNVBAMME1NlbGZTZXJ2
-        aWNlIFNBTUwgU1AxFzAVBgNVBAoMDkRldmVsb3BtZW50IFZNMIIBIjANBgkqhkiG
-        9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhbI0Xy682DuvWchg6FYnI+DNwLXef2XExM4
-        YVRBaMMsOZ3rBtQUTMSqYan6SK/BOEXLs0rNiJjyM0dn+F98wg3fv5zIADlvfk3L
-        BVdcGsrpVfFUWtSa73yMgbROy8/RJADbUJE/HUB3ZmdjdiuD2Cui2aoWwT2HR8uk
-        Jwmoxiu45IWFPbqPQ7/1mH644JPOWTPLTv4OGGLQo8MNrP1oRCiZ0IEL4CQeGOOj
-        u5rfIJ0bTVm0UmelT4hGaqZovBMwXp3QV41akJ7UEMEBK2YMnLQy47Xuzi7aTDhJ
-        lvHcJ8mfH2NbjRh7hJoACVRTvQloxajgkr1iGMiWiiqT0e+YYwIDAQABMA0GCSqG
-        SIb3DQEBCwUAA4IBAQBwZ0gRHvR8B8KivrXrhWNL9uLvWhEAH7OiDqo+fywkBp5K
-        EuDJcbbvEPftHunSAGylg7M2xKuBIGamFpp74WDJccrtZ1jJ4qqnacUDRQrTLqqM
-        ZKqGpFOU0xjKkSxSGRuMtGN9/7er/TeonjQ0XBvjYvTomy3b5aCLVWRvEfKu2g1s
-        Dd8uhr62RY/HfMgidEt7LHDolkCVg+6JzY3OTcgeHga3cvYObOYPplxw1YPq5+Bq
-        qxaUW4nfb5DtK33bZBYMeyV6BZtSggc5Z/19aPx/s0bf6ySTUyB3lRqe5d3etCns
-        4bGidORCl/6EZiXwVcPvmYmxYXqmuNWfps7isUvo
-        -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      MIIC6jCCAdICCQC9cRx5wiwWOjANBgkqhkiG9w0BAQsFADA3MRwwGgYDVQQDDBNT
+      ZWxmU2VydmljZSBTQU1MIFNQMRcwFQYDVQQKDA5EZXZlbG9wbWVudCBWTTAeFw0x
+      ODA3MzAxMjMwNDdaFw0yMzA3MjkxMjMwNDdaMDcxHDAaBgNVBAMME1NlbGZTZXJ2
+      aWNlIFNBTUwgU1AxFzAVBgNVBAoMDkRldmVsb3BtZW50IFZNMIIBIjANBgkqhkiG
+      9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhbI0Xy682DuvWchg6FYnI+DNwLXef2XExM4
+      YVRBaMMsOZ3rBtQUTMSqYan6SK/BOEXLs0rNiJjyM0dn+F98wg3fv5zIADlvfk3L
+      BVdcGsrpVfFUWtSa73yMgbROy8/RJADbUJE/HUB3ZmdjdiuD2Cui2aoWwT2HR8uk
+      Jwmoxiu45IWFPbqPQ7/1mH644JPOWTPLTv4OGGLQo8MNrP1oRCiZ0IEL4CQeGOOj
+      u5rfIJ0bTVm0UmelT4hGaqZovBMwXp3QV41akJ7UEMEBK2YMnLQy47Xuzi7aTDhJ
+      lvHcJ8mfH2NbjRh7hJoACVRTvQloxajgkr1iGMiWiiqT0e+YYwIDAQABMA0GCSqG
+      SIb3DQEBCwUAA4IBAQBwZ0gRHvR8B8KivrXrhWNL9uLvWhEAH7OiDqo+fywkBp5K
+      EuDJcbbvEPftHunSAGylg7M2xKuBIGamFpp74WDJccrtZ1jJ4qqnacUDRQrTLqqM
+      ZKqGpFOU0xjKkSxSGRuMtGN9/7er/TeonjQ0XBvjYvTomy3b5aCLVWRvEfKu2g1s
+      Dd8uhr62RY/HfMgidEt7LHDolkCVg+6JzY3OTcgeHga3cvYObOYPplxw1YPq5+Bq
+      qxaUW4nfb5DtK33bZBYMeyV6BZtSggc5Z/19aPx/s0bf6ySTUyB3lRqe5d3etCns
+      4bGidORCl/6EZiXwVcPvmYmxYXqmuNWfps7isUvo
+      -----END CERTIFICATE-----
     storage_location: '%kernel.project_dir%/app/rv'
 
 services:
@@ -76,11 +76,11 @@ services:
       $session: '@session'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\SamlCalloutHelper:
-      $identityProviderFactory: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\IdentityProviderFactory'
-      $serviceProviderFactory: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\ServiceProviderFactory'
-      $postBinding: '@surfnet_saml.http.post_binding'
-      $remoteVettingService: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService'
-      $logger: '@logger'
+    $identityProviderFactory: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\IdentityProviderFactory'
+    $serviceProviderFactory: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\ServiceProviderFactory'
+    $postBinding: '@surfnet_saml.http.post_binding'
+    $remoteVettingService: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService'
+    $logger: '@logger'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService:
     arguments:
@@ -108,8 +108,8 @@ services:
       - '@twig'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Mock\RemoteVetting\MockGateway:
-      arguments:
-        - '@Surfnet\StepupSelfService\SelfServiceBundle\Mock\RemoteVetting\MockConfiguration'
+    arguments:
+      - '@Surfnet\StepupSelfService\SelfServiceBundle\Mock\RemoteVetting\MockConfiguration'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Encryption\IdentityFilesystemWriter:
     arguments:

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -14,6 +14,8 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_DIR" value="../app/" />
+        <server name="KERNEL_CLASS" value="AppKernel" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
     <testsuites>
         <testsuite name="Project Test Suite">

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
@@ -125,7 +125,7 @@ class RemoteVettingController extends Controller
 
         $form = $this->createForm(RemoteVetSecondFactorType::class, $command)->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $token = RemoteVettingTokenDto::create(
                 $command->identity->id,
                 $command->secondFactor->id
@@ -213,7 +213,7 @@ class RemoteVettingController extends Controller
             $command->matches = AttributeMatchCollection::fromAttributeCollection($attributes->getAttributes());
 
             $form = $this->createForm(RemoteVetValidationType::class, $command)->handleRequest($request);
-            if ($form->isValid()) {
+            if ($form->isSubmitted() && $form->isValid()) {
 
                 /** @var RemoteVetValidationCommand $command */
                 $command = $form->getData();

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
@@ -165,7 +165,7 @@ class RemoteVettingController extends Controller
             return $this->redirectToRoute('ss_second_factor_list');
         } catch (Exception $e) {
             //PreconditionNotMetException $e) {
-            // todo: add saml specific logging?
+            // todo: add saml specific logging (user flashbag may differ) ?
             $this->logger->error($e->getMessage());
             $flashBag->add('error', 'ss.second_factor.revoke.alert.remote_vetting_failed');
             return $this->redirectToRoute('ss_second_factor_list');
@@ -193,8 +193,6 @@ class RemoteVettingController extends Controller
      */
     public function remoteVetMatchAction(Request $request, $processId)
     {
-        $this->logger->info('Matching remote vetting second factor');
-
         /** @var FlashBagInterface $flashBag */
         $flashBag = $this->get('session')->getFlashBag();
 
@@ -242,7 +240,7 @@ class RemoteVettingController extends Controller
             }
 
             return $this->render('SurfnetStepupSelfServiceSelfServiceBundle:RemoteVetting:validation.html.twig', [
-                'form' => $form->createView()
+                'form' => $form->createView(),
             ]);
         } catch (InvalidRemoteVettingStateException $e) {
             $this->logger->error($e->getMessage());

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Mock/RemoteVetting/MockRemoteVetController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Mock/RemoteVetting/MockRemoteVetController.php
@@ -72,6 +72,7 @@ class MockRemoteVetController extends Controller
                 $body = $this->twig->render(
                     'dev/mock-acs.html.twig',
                     [
+                        'action' => $request->getUri(),
                         'responses' => [
                             'success',
                             'user-cancelled',

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -1,14 +1,13 @@
 {% extends "::base.html.twig" %}
-{% import _self as macro %}
 
 {% block page_title %}{{ 'ss.second_factor.list.title'|trans }}{% endblock %}
 
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-    {{ macro.secondFactorTable(vettedSecondFactors, 'ss.second_factor.list.text.vetted', 'vetted', email, expirationHelper) }}
-    {{ macro.secondFactorTable(verifiedSecondFactors, 'ss.second_factor.list.text.verified', 'verified', email, expirationHelper) }}
-    {{ macro.secondFactorTable(unverifiedSecondFactors, 'ss.second_factor.list.text.unverified', 'unverified', email, expirationHelper) }}
+    {{ _self.secondFactorTable(vettedSecondFactors, 'ss.second_factor.list.text.vetted', 'vetted', email, expirationHelper) }}
+    {{ _self.secondFactorTable(verifiedSecondFactors, 'ss.second_factor.list.text.verified', 'verified', email, expirationHelper) }}
+    {{ _self.secondFactorTable(unverifiedSecondFactors, 'ss.second_factor.list.text.unverified', 'unverified', email, expirationHelper) }}
 
     <div class="btn-toolbar token-button-group" role="toolbar">
     {% if vettedSecondFactors.elements is not empty %}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/SamlCalloutHelper.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/SamlCalloutHelper.php
@@ -120,7 +120,7 @@ class SamlCalloutHelper
         // Create log DTO in order to store
         $attributeLogDto = new AttributeListDto(
             $assertion->getAttributes(),
-            $subjectConfirmation->NameID,
+            (string)$subjectConfirmation->NameID,
             $assertion->toXML()->ownerDocument->saveXML()
         );
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVettingService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVettingService.php
@@ -125,13 +125,13 @@ class RemoteVettingService
     private function fromAttributeSet(AttributeSet $attributeSet)
     {
         $attributes = [];
-        $nameID = null;
+        $nameID = '';
         /** @var \Surfnet\SamlBundle\SAML2\Attribute\Attribute $attribute */
         foreach ($attributeSet as $attribute) {
             $values = $attribute->getValue();
             foreach ($values as $value) {
                 if ($value instanceof NameID) {
-                    $nameID = $value->value;
+                    $nameID = (string)$value->value;
                     continue;
                 }
                 $attributes[$attribute->getAttributeDefinition()->getName()] = $values;

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Mock/RemoteVetting/MockRemoteVetControllerTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Mock/RemoteVetting/MockRemoteVetControllerTest.php
@@ -65,8 +65,13 @@ class MockRemoteVetControllerTest extends WebTestCase
      */
     private $samlCalloutHelper;
 
-    protected function setUp()
-    {
+    protected function setUp() {
+
+        // This is a fix to prevent segfaults in php 5.6 on Travis
+        if (version_compare(phpversion(), '7', '<')) {
+               ini_set('zend.enable_gc', '0');
+        }
+
         $this->client = static::createClient(['environment' => 'test']);
         $this->client->followRedirects(true);
 


### PR DESCRIPTION
Disable garbage collection for acceptance test

For the acceptance tests the garbage collection is disabled in
order to prevent a segfaults in Travis. This should be fixed in php 7.

See: https://bugs.php.net/bug.php?id=72286