### PR TITLE
Add data mapper for form attribute matches

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Command/RemoteVetValidationCommand.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Command/RemoteVetValidationCommand.php
@@ -18,21 +18,12 @@
 
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Command;
 
-use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
-use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\VerifiedSecondFactor;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\AttributeMatchCollection;
-use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\ProcessId;
-use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\AttributeMatch;
 
 class RemoteVetValidationCommand
 {
     /**
-     * The attributes and their state
-     *
-     *  [key => [
-     *      'valid' => true,
-     *      'remarks' => 'remarks',
-     *  ]]
+     * The attribute matches
      *
      * @var AttributeMatchCollection
      */

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetAssertionMatchType.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetAssertionMatchType.php
@@ -18,16 +18,17 @@
 
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Form\Type;
 
-use Surfnet\StepupSelfService\SelfServiceBundle\Command\RemoteVetValidationCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\AttributeMatch;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class RemoteVetAssertionMatchType extends AbstractType
+class RemoteVetAssertionMatchType extends AbstractType implements DataMapperInterface
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -40,6 +41,8 @@ class RemoteVetAssertionMatchType extends AbstractType
             'label'    => 'REMARKS',
             'required' => false,
         ]);
+
+        $builder->setDataMapper($this);
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -52,5 +55,44 @@ class RemoteVetAssertionMatchType extends AbstractType
     public function getBlockPrefix()
     {
         return 'ss_remote_vet_assertion';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function mapDataToForms($viewData, $forms)
+    {
+        // there is no data yet, so nothing to prepopulate
+        if (null === $viewData) {
+            return;
+        }
+
+        // invalid data type
+        if (!$viewData instanceof AttributeMatch) {
+            throw new UnexpectedTypeException($viewData, AttributeMatch::class);
+        }
+
+        /** @var FormInterface[] $forms */
+        $forms = iterator_to_array($forms);
+
+        // Set VO values to form
+        $forms['valid']->setData($viewData->isValid());
+        $forms['remarks']->setData($viewData->getRemarks());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function mapFormsToData($forms, &$viewData)
+    {
+        /** @var FormInterface[] $forms */
+        $forms = iterator_to_array($forms);
+
+        // Keep the name from the original object
+        $viewData = new AttributeMatch(
+            $viewData->getName(),
+            $forms['valid']->getData(),
+            $forms['remarks']->getData()
+        );
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatch.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatch.php
@@ -19,22 +19,52 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Valu
 
 class AttributeMatch
 {
-    public function __construct($name)
+    /**
+     * @var bool
+     */
+    private $valid;
+    /**
+     * @var string
+     */
+    private $remarks = '';
+    /**
+     * @var string
+     */
+    private $name = '';
+
+    /**
+     * @param string $name
+     * @param bool $valid
+     * @param string $remarks
+     */
+    public function __construct($name, $valid, $remarks)
     {
         $this->name = $name;
+        $this->valid = $valid;
+        $this->remarks = $remarks;
     }
 
     /**
-     * The attributes and their state
-     *
-     *  [key => [
-     *      'valid' => true,
-     *      'remarks' => 'remarks',
-     *  ]]
-     *
+     * @return bool
      */
+    public function isValid()
+    {
+        return $this->valid;
+    }
 
-    public $valid = false;
-    public $remarks = '';
-    public $name = '';
+    /**
+     * @return string
+     */
+    public function getRemarks()
+    {
+        return $this->remarks;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatchCollection.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatchCollection.php
@@ -34,7 +34,7 @@ class AttributeMatchCollection implements JsonSerializable, IteratorAggregate, A
     {
         $instance = new self();
         foreach ($attributeCollection as $attribute) {
-            $match = new AttributeMatch($attribute->getName());
+            $match = new AttributeMatch($attribute->getName(), false, '');
             $instance->matches[$attribute->getName()] = $match;
         }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVettingService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVettingService.php
@@ -128,13 +128,14 @@ class RemoteVettingService
         $nameID = '';
         /** @var \Surfnet\SamlBundle\SAML2\Attribute\Attribute $attribute */
         foreach ($attributeSet as $attribute) {
+            $name = $attribute->getAttributeDefinition()->getName();
             $values = $attribute->getValue();
             foreach ($values as $value) {
                 if ($value instanceof NameID) {
                     $nameID = (string)$value->value;
                     continue;
                 }
-                $attributes[$attribute->getAttributeDefinition()->getName()] = $values;
+                $attributes[$name] = $values;
             }
         }
 


### PR DESCRIPTION
The attrbute matches needed to be mapped with DI.
This is done with the help of a datamapper.

Please review #187 first.
Be aware that the base branch has to be changed before merging.