### PR TITLE
Add attribute mapping config

### DIFF
--- a/app/config/remote_vetting.yml
+++ b/app/config/remote_vetting.yml
@@ -12,6 +12,9 @@ parameters:
         ssoUrl: https://selfservice.stepup.example.com/second-factor/mock/sso
         certificateFile: "%saml_rv_publickey%"
         privateKey: "%saml_rv_privatekey%"
+        attributeMapping:
+          mail: mail
+          uid: uid
       - name: "ReadId"
         logo: "/images/remote-vetting/readid.png"
         description:
@@ -21,6 +24,9 @@ parameters:
         ssoUrl: https://selfservice.stepup.example.com/second-factor/mock/sso
         certificateFile: "%saml_rv_publickey%"
         privateKey: "%saml_rv_privatekey%"
+        attributeMapping:
+          mail: mail
+          uid: uid
       - name: "iDIN"
         logo: "/images/remote-vetting/idin.png"
         description:
@@ -30,6 +36,9 @@ parameters:
         ssoUrl: https://selfservice.stepup.example.com/second-factor/mock/sso
         certificateFile: '%saml_rv_publickey%'
         privateKey: '%saml_rv_privatekey%'
+        attributeMapping:
+          mail: mail
+          uid: uid
   remote_vetting_sp:
     entityId: https://selfservice.stepup.example.com/saml/metadata
     assertionConsumerUrl: https://selfservice.stepup.example.com/second-factor/acs
@@ -82,10 +91,14 @@ services:
     $remoteVettingService: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService'
     $logger: '@logger'
 
+  Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\AttributeMapper:
+    $identityProviderFactory: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\IdentityProviderFactory'
+
   Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService:
     public: true
     arguments:
       $remoteVettingContext: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\RemoteVettingContext'
+      $attributeMapper: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\AttributeMapper'
       $identityEncrypter: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Encryption\IdentityEncrypter'
       $logger: '@logger'
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
@@ -20,7 +20,6 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Controller;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\RemoteVetCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\RemoteVetValidationCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Exception\InvalidRemoteVettingStateException;
@@ -131,10 +130,12 @@ class RemoteVettingController extends Controller
                 $command->secondFactor->id
             );
 
-            $this->remoteVettingService->start($token);
-
             // todo : implement idp selection
-            return new RedirectResponse($this->samlCalloutHelper->createAuthnRequest('IRMA'));
+            $identityProviderName = 'IRMA';
+
+            $this->remoteVettingService->start($identityProviderName, $token);
+
+            return new RedirectResponse($this->samlCalloutHelper->createAuthnRequest($identityProviderName));
         }
 
         return [
@@ -196,7 +197,7 @@ class RemoteVettingController extends Controller
         /** @var FlashBagInterface $flashBag */
         $flashBag = $this->get('session')->getFlashBag();
 
-        /** @var AttributeSet $attributes */
+        /** @var SamlToken $samlToken */
         $samlToken = $this->container->get('security.token_storage')->getToken();
         $attributes = $samlToken->getAttribute(SamlToken::ATTRIBUTE_SET);
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetAssertionMatchType.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetAssertionMatchType.php
@@ -33,7 +33,7 @@ class RemoteVetAssertionMatchType extends AbstractType implements DataMapperInte
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('valid', CheckboxType::class, [
-            'label'    => 'VALID',
+            'label'    => 'valid',
             'required' => false,
         ]);
 
@@ -91,6 +91,7 @@ class RemoteVetAssertionMatchType extends AbstractType implements DataMapperInte
         // Keep the name from the original object
         $viewData = new AttributeMatch(
             $viewData->getName(),
+            $viewData->getValue(),
             $forms['valid']->getData(),
             $forms['remarks']->getData()
         );

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetValidationType.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetValidationType.php
@@ -37,6 +37,7 @@ class RemoteVetValidationType extends AbstractType
             // these options are passed to each "email" type
             'entry_options' => [
                 'attr' => ['class' => 'assertion_match'],
+                'label' => false,
             ],
         ]);
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Form/fields.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Form/fields.html.twig
@@ -30,3 +30,16 @@
         {% endif %}
     {% endspaceless %}
 {% endblock anchor_row %}
+
+
+{# Show value in the remote vetting attribute match. #}
+{% block ss_remote_vet_assertion_widget %}
+    {% spaceless %}
+        <div class="text_widget">
+            <h3>{{ form.vars.data.name }}: '{{ form.vars.data.value|join(', ') }}'</h3>
+
+            {{ form_widget(form) }}
+
+        </div>
+    {% endspaceless %}
+{% endblock %}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/AttributeMapper.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/AttributeMapper.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting;
+
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Dto\AttributeListDto;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\Attribute;
+
+class AttributeMapper
+{
+    /**
+     * @var IdentityProviderFactory
+     */
+    private $identityProviderFactory;
+
+    public function __construct(IdentityProviderFactory $identityProviderFactory)
+    {
+        $this->identityProviderFactory = $identityProviderFactory;
+    }
+
+    /**
+     * @param string $identityProviderName
+     * @param AttributeListDto $localAttributes
+     * @param AttributeListDto $externalAttributes
+     * @return AttributeListDto
+     */
+    public function map($identityProviderName, AttributeListDto $localAttributes, AttributeListDto $externalAttributes)
+    {
+        $attributeMapping = $this->identityProviderFactory->getAttributeMapping($identityProviderName);
+
+        $mappedAttributes = [];
+        $attributesToMap = [];
+
+        foreach ($localAttributes->getAttributes() as $attribute) {
+            if (array_key_exists($attribute->getName(), $attributeMapping)) {
+                $attributesToMap[$attributeMapping[$attribute->getName()]] = $attribute->getName();
+                $mappedAttributes[$attribute->getName()] = null;
+            }
+        }
+
+        foreach ($externalAttributes->getAttributes() as $attribute) {
+            if (array_key_exists($attribute->getName(), $attributesToMap)) {
+                $mappedAttributes[$attributesToMap[$attribute->getName()]] = $attribute->getValue();
+            }
+        }
+
+        $mappedAttributes = array_filter($mappedAttributes);
+
+        return new AttributeListDto($mappedAttributes, $localAttributes->getNameId());
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Dto/AttributeListDto.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Dto/AttributeListDto.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Dto;
 
 use Serializable;
 use Surfnet\StepupSelfService\SelfServiceBundle\Assert;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\Attribute;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\AttributeCollection;
 
 /**
@@ -68,7 +69,7 @@ class AttributeListDto implements Serializable
     }
 
     /**
-     * @return AttributeCollection
+     * @return AttributeCollection|Attribute[]
      */
     public function getAttributes()
     {
@@ -100,5 +101,13 @@ class AttributeListDto implements Serializable
 
         $this->nameId = $data['nameId'];
         $this->attributes = new AttributeCollection($data['attributes']);
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameId()
+    {
+        return $this->nameId;
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/RemoteVettingContext.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/RemoteVettingContext.php
@@ -60,11 +60,12 @@ class RemoteVettingContext
     }
 
     /**
+     * @param string $identityProviderName
      * @param RemoteVettingTokenDto $token
      */
-    public function initialize(RemoteVettingTokenDto $token)
+    public function initialize($identityProviderName, RemoteVettingTokenDto $token)
     {
-        $process = $this->state->handleInitialise($this, $token);
+        $process = $this->state->handleInitialise($this, $identityProviderName, $token);
         $this->saveProcess($process);
     }
 
@@ -117,6 +118,15 @@ class RemoteVettingContext
     {
         $process = $this->loadProcess();
         return $this->state->getAttributes($process);
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentityProviderName()
+    {
+        $process = $this->loadProcess();
+        return $process->getIdentityProviderName();
     }
 
     /**

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/SamlCalloutHelper.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/SamlCalloutHelper.php
@@ -18,6 +18,7 @@
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting;
 
 use Psr\Log\LoggerInterface;
+use SAML2\Assertion;
 use SAML2\Constants;
 use SAML2\XML\saml\SubjectConfirmation;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
@@ -120,8 +121,7 @@ class SamlCalloutHelper
         // Create log DTO in order to store
         $attributeLogDto = new AttributeListDto(
             $assertion->getAttributes(),
-            (string)$subjectConfirmation->NameID,
-            $assertion->toXML()->ownerDocument->saveXML()
+            (string)$subjectConfirmation->NameID
         );
 
         // Handle validated state

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/State/AbstractRemoteVettingState.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/State/AbstractRemoteVettingState.php
@@ -34,7 +34,7 @@ abstract class AbstractRemoteVettingState
     {
     }
 
-    public function handleInitialise(RemoteVettingContext $context, RemoteVettingTokenDto $token)
+    public function handleInitialise(RemoteVettingContext $context, $identityProviderName, RemoteVettingTokenDto $token)
     {
         throw new InvalidRemoteVettingStateException('Unable to initialise the validation of a token');
     }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/State/RemoteVettingState.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/State/RemoteVettingState.php
@@ -31,11 +31,12 @@ interface RemoteVettingState
     public function __construct();
 
     /**
+     * @param string $identityProviderName
      * @param RemoteVettingContext $context
      * @param RemoteVettingTokenDto $token
      * @return RemoteVettingProcessDto
      */
-    public function handleInitialise(RemoteVettingContext $context, RemoteVettingTokenDto $token);
+    public function handleInitialise(RemoteVettingContext $context, $identityProviderName, RemoteVettingTokenDto $token);
 
     /**
      * @param RemoteVettingContext $context

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/State/RemoteVettingStateInitialised.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/State/RemoteVettingStateInitialised.php
@@ -24,9 +24,9 @@ use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\Proc
 
 class RemoteVettingStateInitialised extends AbstractRemoteVettingState implements RemoteVettingState
 {
-    public function handleInitialise(RemoteVettingContext $context, RemoteVettingTokenDto $token)
+    public function handleInitialise(RemoteVettingContext $context, $identityProviderName, RemoteVettingTokenDto $token)
     {
-        return RemoteVettingProcessDto::create(ProcessId::notSet(), $token);
+        return RemoteVettingProcessDto::create(ProcessId::notSet(), $token, $identityProviderName);
     }
 
     public function handleValidating(RemoteVettingContext $context, RemoteVettingProcessDto $process, ProcessId $id)
@@ -34,6 +34,6 @@ class RemoteVettingStateInitialised extends AbstractRemoteVettingState implement
         // set new process id on validation start
         $context->setState(new RemoteVettingStateValidating());
 
-        return RemoteVettingProcessDto::create($id, $process->getToken());
+        return RemoteVettingProcessDto::create($id, $process->getToken(), $process->getIdentityProviderName());
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeCollection.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeCollection.php
@@ -45,7 +45,6 @@ class AttributeCollection implements IteratorAggregate
         $this->attributes[] = $attribute;
     }
 
-
     public function getIterator()
     {
         return new ArrayIterator($this->attributes);

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatch.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatch.php
@@ -17,6 +17,8 @@
 
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value;
 
+use Surfnet\StepupSelfService\SelfServiceBundle\Assert;
+
 class AttributeMatch
 {
     /**
@@ -31,17 +33,29 @@ class AttributeMatch
      * @var string
      */
     private $name = '';
+    /**
+     * @var string
+     */
+    private $value = '';
 
     /**
      * @param string $name
+     * @param string $value
      * @param bool $valid
      * @param string $remarks
+     * @throws \Assert\AssertionFailedException
      */
-    public function __construct($name, $valid, $remarks)
+    public function __construct($name, $value, $valid, $remarks)
     {
+        Assert::string($name, 'name should be string');
+        Assert::string($value, 'value should be string');
+        Assert::boolean($valid, 'valid should be boolean');
+        Assert::string($remarks, 'remarks should be string');
+
         $this->name = $name;
         $this->valid = $valid;
         $this->remarks = $remarks;
+        $this->value = $value;
     }
 
     /**
@@ -66,5 +80,13 @@ class AttributeMatch
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatchCollection.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatchCollection.php
@@ -34,7 +34,7 @@ class AttributeMatchCollection implements IteratorAggregate, ArrayAccess
     {
         $instance = new self();
         foreach ($attributeCollection as $attribute) {
-            $match = new AttributeMatch($attribute->getName(), false, '');
+            $match = new AttributeMatch($attribute->getName(), $attribute->getValue(), false, '');
             $instance->matches[$attribute->getName()] = $match;
         }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Mock/RemoteVetting/MockRemoteVetControllerTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Mock/RemoteVetting/MockRemoteVetControllerTest.php
@@ -95,7 +95,7 @@ class MockRemoteVetControllerTest extends WebTestCase
     public function the_mock_remote_vetting_idp_should_present_us_with_possible_results_for_testing_purposes()
     {
         $this->logIn();
-        $this->remoteVettingService->start(RemoteVettingTokenDto::create('identity-id-123456', 'second-factor-id-56789'));
+        $this->remoteVettingService->start('IRMA',  RemoteVettingTokenDto::create('identity-id-123456', 'second-factor-id-56789'));
         $authnRequestUrl = $this->samlCalloutHelper->createAuthnRequest('MockIdP');
 
         $crawler = $this->client->request('GET', $authnRequestUrl);
@@ -112,7 +112,7 @@ class MockRemoteVetControllerTest extends WebTestCase
     public function a_succesful_response_from_a_remote_vetting_idp_should_succeed()
     {
         $this->logIn();
-        $this->remoteVettingService->start(RemoteVettingTokenDto::create('identity-id-123456', 'second-factor-id-56789'));
+        $this->remoteVettingService->start('IRMA', RemoteVettingTokenDto::create('identity-id-123456', 'second-factor-id-56789'));
         $authnRequestUrl = $this->samlCalloutHelper->createAuthnRequest('MockIdP');
 
         $crawler = $this->client->request('GET', $authnRequestUrl);
@@ -134,7 +134,7 @@ class MockRemoteVetControllerTest extends WebTestCase
     public function a_user_cancelled_response_from_a_remote_vetting_idp_should_fail()
     {
         $this->logIn();
-        $this->remoteVettingService->start(RemoteVettingTokenDto::create('identity-id-123456', 'second-factor-id-56789'));
+        $this->remoteVettingService->start('IRMA', RemoteVettingTokenDto::create('identity-id-123456', 'second-factor-id-56789'));
         $authnRequestUrl = $this->samlCalloutHelper->createAuthnRequest('MockIdP');
 
         $crawler = $this->client->request('GET', $authnRequestUrl);
@@ -155,7 +155,7 @@ class MockRemoteVetControllerTest extends WebTestCase
     public function an_unsuccessful_response_from_a_remote_vetting_idp_should_fail()
     {
         $this->logIn();
-        $this->remoteVettingService->start(RemoteVettingTokenDto::create('identity-id-123456', 'second-factor-id-56789'));
+        $this->remoteVettingService->start('IRMA', RemoteVettingTokenDto::create('identity-id-123456', 'second-factor-id-56789'));
         $authnRequestUrl = $this->samlCalloutHelper->createAuthnRequest('MockIdP');
 
         $crawler = $this->client->request('GET', $authnRequestUrl);

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/AttributeMapperTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/AttributeMapperTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright 2020 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Tests\Service\RemoteVetting;
+
+use Mockery as m;
+use PHPUnit_Framework_TestCase as UnitTest;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Dto\AttributeListDto;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\IdentityProviderFactory;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\AttributeMapper;
+
+class AttributeMapperTest extends UnitTest
+{
+    /**
+     * @var IdentityProviderFactory|m\Mock
+     */
+    private $identityProviderFactory;
+    /**
+     * @var AttributeMapper
+     */
+    private $attributeMapper;
+
+    public function setUp()
+    {
+        $this->identityProviderFactory = m::mock(IdentityProviderFactory::class);
+        $this->attributeMapper = new AttributeMapper($this->identityProviderFactory);
+    }
+
+    public function test_attribute_mapping()
+    {
+        $config = [
+            'foo2' => 'baz2',
+            'foo3' => 'baz1',
+        ];
+
+        $nameId = 'foo@bar.baz';
+        $local = [
+            'foo1' => 'bar1',
+            'foo2' => 'bar2',
+            'foo3' => 'bar3',
+        ];
+        $external = [
+            'baz1' => 'foobar1',
+            'baz2' => 'foobar2',
+            'baz3' => 'foobar3',
+        ];
+
+        $this->identityProviderFactory->shouldReceive('getAttributeMapping')
+            ->andReturn($config);
+
+        $localAttributes = new AttributeListDto($local, $nameId);
+        $externalAttributes = new AttributeListDto($external, '');
+
+        $mappedAttributes = $this->attributeMapper->map('idp-name', $localAttributes, $externalAttributes);
+
+        $result = $mappedAttributes->serialize();
+
+        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo2":"foobar2","foo3":"foobar1"}}', $result);
+    }
+
+
+    public function test_attribute_mapping_missing_local()
+    {
+        $config = [
+            'MISSING' => 'baz2',
+            'foo3' => 'baz1',
+        ];
+
+        $nameId = 'foo@bar.baz';
+        $local = [
+            'foo1' => 'bar1',
+            'foo2' => 'bar2',
+            'foo3' => 'bar3',
+        ];
+        $external = [
+            'baz1' => 'foobar1',
+            'baz2' => 'foobar2',
+            'baz3' => 'foobar3',
+        ];
+
+        $this->identityProviderFactory->shouldReceive('getAttributeMapping')
+            ->andReturn($config);
+
+        $localAttributes = new AttributeListDto($local, $nameId);
+        $externalAttributes = new AttributeListDto($external, '');
+
+        $mappedAttributes = $this->attributeMapper->map('idp-name', $localAttributes, $externalAttributes);
+
+        $result = $mappedAttributes->serialize();
+
+        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo3":"foobar1"}}', $result);
+    }
+
+
+
+    public function test_attribute_mapping_missing_external()
+    {
+        $config = [
+            'foo2' => 'MISSING',
+            'foo3' => 'baz1',
+        ];
+
+        $nameId = 'foo@bar.baz';
+        $local = [
+            'foo1' => 'bar1',
+            'foo2' => 'bar2',
+            'foo3' => 'bar3',
+        ];
+        $external = [
+            'baz1' => 'foobar1',
+            'baz2' => 'foobar2',
+            'baz3' => 'foobar3',
+        ];
+
+        $this->identityProviderFactory->shouldReceive('getAttributeMapping')
+            ->andReturn($config);
+
+        $localAttributes = new AttributeListDto($local, $nameId);
+        $externalAttributes = new AttributeListDto($external, '');
+
+        $mappedAttributes = $this->attributeMapper->map('idp-name', $localAttributes, $externalAttributes);
+
+        $result = $mappedAttributes->serialize();
+
+        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo3":"foobar1"}}', $result);
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Dto/RemoteVettingProcessDtoTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Dto/RemoteVettingProcessDtoTest.php
@@ -36,12 +36,12 @@ class RemoteVettingProcessDtoTest extends Unittest
     public function a_process_could_be_serialized_and_deserialized($name, $state, $expected)
     {
         $attributes = new AttributeListDto(['foo' => 'bar'], 'nameId');
-        $expected = sprintf('{"processId":"process id","token":"{\"identityId\":\"identityId\",\"secondFactorId\":\"secondFactorId\"}","state":%s,"attributes":"{\"nameId\":\"nameId\",\"attributes\":{\"foo\":\"bar\"}}"}', json_encode($expected));
+        $expected = sprintf('{"processId":"process id","token":"{\"identityId\":\"identityId\",\"secondFactorId\":\"secondFactorId\"}","state":%s,"attributes":"{\"nameId\":\"nameId\",\"attributes\":{\"foo\":\"bar\"}}","identityProvider":"IRMA"}', json_encode($expected));
 
         $processId = ProcessId::create('process id');
         $token = RemoteVettingTokenDto::create('identityId', 'secondFactorId');
 
-        $processDto = RemoteVettingProcessDto::create($processId, $token);
+        $processDto = RemoteVettingProcessDto::create($processId, $token, 'IRMA');
 
         $processDto = RemoteVettingProcessDto::updateState($processDto, $state);
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/RemoteVettingContextTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/RemoteVettingContextTest.php
@@ -55,9 +55,9 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
-        $context->initialize($token2, AttributeListDto::notSet());
-        $context->initialize($token3, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token2, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token3, AttributeListDto::notSet());
     }
 
     /**
@@ -71,7 +71,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
         $context->validating($processId);
         $context->validated($processId, AttributeListDto::notSet());
         $context->done($processId);
@@ -95,7 +95,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
         $context->validating($processId);
         $context->validated($processId, AttributeListDto::notSet());
 
@@ -117,7 +117,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
         $context->validating($processId);
         $context->validated($processId, AttributeListDto::notSet());
 
@@ -138,7 +138,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
         $context->validating($processId);
 
         $context->getValidatedToken();
@@ -157,7 +157,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
 
         $context->getValidatedToken();
     }
@@ -207,7 +207,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
         //$context->validating($processId);
         $context->validated($processId, AttributeListDto::notSet());
     }
@@ -226,7 +226,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
         $context->validating($processId);
         //$context->validated($processId);
         $context->done($processId);
@@ -248,7 +248,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
         $context->validating($processId);
         $context->validated($wrongProcessId, AttributeListDto::notSet());
     }
@@ -269,7 +269,7 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context = new RemoteVettingContext($this->session);
 
-        $context->initialize($token, AttributeListDto::notSet());
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
         $context->validating($processId);
         $context->validated($wrongProcessId, AttributeListDto::notSet());
         $context->validated($processId, AttributeListDto::notSet());
@@ -324,6 +324,24 @@ class RemoteVettingContextTest extends IntegrationTest
 
         $context->done($processId);
     }
+
+
+    /**
+     * @test
+     * @group rv
+     */
+    public function a_remote_vetting_process_holds_the_name_of_the_identity_provider()
+    {
+        $token = $this->createToken();
+
+        $context = new RemoteVettingContext($this->session);
+
+        $context->initialize('IRMA', $token, AttributeListDto::notSet());
+
+
+        $this->assertSame('IRMA', $context->getIdentityProviderName());
+    }
+
 
     /**
      * @return RemoteVettingTokenDto


### PR DESCRIPTION
Add mapper to map local and external (remote vetting) attributes so they can be used to match values on. Currently, only a form is filled in order to select valid attributes.

https://www.pivotaltracker.com/story/show/171571478