### PR TITLE
 Allow multi value attributes

### DIFF
--- a/app/config/services_dev.yml
+++ b/app/config/services_dev.yml
@@ -3,7 +3,7 @@
 
 services:
   Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Encryption\IdentityEncrypter:
+    class: \Surfnet\StepupSelfService\SelfServiceBundle\Tests\Service\RemoteVetting\Encryption\FakeIdentityEncrypter
     arguments:
       $configuration: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Configuration\RemoteVettingConfiguration'
       $writer: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Encryption\IdentityFilesystemWriter'
-

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
@@ -213,7 +213,6 @@ class RemoteVettingController extends Controller
         $attributes = AttributeListDto::fromAttributeSet($samlToken->getAttribute(SamlToken::ATTRIBUTE_SET));
 
         $command = new RemoteVetValidationCommand();
-        $command->processId = $processId;
 
         try {
             $remoteVettingAttributes = $this->remoteVettingService->getValidatingAttributes(
@@ -233,7 +232,7 @@ class RemoteVettingController extends Controller
                 $nameId = $this->getIdentity()->nameId;
                 $institution = $this->getIdentity()->institution;
                 $version = $this->applicationHelper->getApplicationVersion();
-                $remarks = $command->remarks;
+                $remarks = (string)$command->remarks;
                 $remoteVettingSource = 'Todo, set the correct RV IdP!';
 
                 $attributeCollectionAggregate = new AttributeCollectionAggregate();

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetAssertionMatchType.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetAssertionMatchType.php
@@ -93,7 +93,7 @@ class RemoteVetAssertionMatchType extends AbstractType implements DataMapperInte
             $viewData->getName(),
             $viewData->getValue(),
             $forms['valid']->getData(),
-            $forms['remarks']->getData()
+            (string)$forms['remarks']->getData()
         );
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Dto/AttributeListDto.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Dto/AttributeListDto.php
@@ -71,11 +71,6 @@ class AttributeListDto implements Serializable, AttributeCollectionInterface
                     continue;
                 }
 
-                // Singular values wrapped in an array are extracted for convenience
-                if (is_array($values) && count($values) === 1) {
-                    $values = reset($values);
-                }
-
                 $attributes[$name] = $values;
             }
         }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/Attribute.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/Attribute.php
@@ -32,19 +32,16 @@ class Attribute implements JsonSerializable
 
     /**
      * @param string $name
-     * @param string|array $value
+     * @param string[] $value
      */
     public function __construct($name, $value)
     {
         Assert::string($name, 'The $name of an Attribute must be a scalar value');
+        Assert::isArray($value, 'The $value of an Attribute must be an array with strings');
+        Assert::allString($value, 'The $value of an Attribute must be an array with strings');
+
         $this->name = $name;
-        try {
-            Assert::scalar($value, 'The $value of an Attribute must be a scalar or array value');
-        } catch (AssertionFailedException $e) {
-            Assert::isArray($value, 'The $value of an Attribute must be a scalar or array value');
-            Assert::allScalar($value, 'The $value of an Attribute must be a scalar or array value');
-        }
-        $this->value = $value;
+        $this->value = array_values($value);
     }
 
     /**
@@ -56,7 +53,7 @@ class Attribute implements JsonSerializable
     }
 
     /**
-     * @return array|string
+     * @return string[]
      */
     public function getValue()
     {

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatch.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeMatch.php
@@ -41,7 +41,7 @@ class AttributeMatch implements JsonSerializable
 
     /**
      * @param string $name
-     * @param string $value
+     * @param string[] $value
      * @param bool $valid
      * @param string $remarks
      * @throws \Assert\AssertionFailedException
@@ -49,7 +49,8 @@ class AttributeMatch implements JsonSerializable
     public function __construct($name, $value, $valid, $remarks)
     {
         Assert::string($name, 'name should be string');
-        Assert::string($value, 'value should be string');
+        Assert::isArray($value, 'value should be an array');
+        Assert::allString($value, 'values should be string');
         Assert::boolean($valid, 'valid should be boolean');
         Assert::string($remarks, 'remarks should be string');
 
@@ -84,7 +85,7 @@ class AttributeMatch implements JsonSerializable
     }
 
     /**
-     * @return string
+     * @return string[]
      */
     public function getValue()
     {

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/AttributeMapperTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/AttributeMapperTest.php
@@ -49,14 +49,14 @@ class AttributeMapperTest extends UnitTest
 
         $nameId = 'foo@bar.baz';
         $local = [
-            'foo1' => 'bar1',
-            'foo2' => 'bar2',
-            'foo3' => 'bar3',
+            'foo1' => ['bar1'],
+            'foo2' => ['bar2'],
+            'foo3' => ['bar3'],
         ];
         $external = [
-            'baz1' => 'foobar1',
-            'baz2' => 'foobar2',
-            'baz3' => 'foobar3',
+            'baz1' => ['foobar1'],
+            'baz2' => ['foobar2'],
+            'baz3' => ['foobar3'],
         ];
 
         $this->identityProviderFactory->shouldReceive('getAttributeMapping')
@@ -69,7 +69,7 @@ class AttributeMapperTest extends UnitTest
 
         $result = $mappedAttributes->serialize();
 
-        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo2":"foobar2","foo3":"foobar1"}}', $result);
+        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo2":["foobar2"],"foo3":["foobar1"]}}', $result);
     }
 
 
@@ -82,14 +82,14 @@ class AttributeMapperTest extends UnitTest
 
         $nameId = 'foo@bar.baz';
         $local = [
-            'foo1' => 'bar1',
-            'foo2' => 'bar2',
-            'foo3' => 'bar3',
+            'foo1' => ['bar1'],
+            'foo2' => ['bar2'],
+            'foo3' => ['bar3'],
         ];
         $external = [
-            'baz1' => 'foobar1',
-            'baz2' => 'foobar2',
-            'baz3' => 'foobar3',
+            'baz1' => ['foobar1'],
+            'baz2' => ['foobar2'],
+            'baz3' => ['foobar3'],
         ];
 
         $this->identityProviderFactory->shouldReceive('getAttributeMapping')
@@ -102,7 +102,7 @@ class AttributeMapperTest extends UnitTest
 
         $result = $mappedAttributes->serialize();
 
-        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo3":"foobar1"}}', $result);
+        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo3":["foobar1"]}}', $result);
     }
 
 
@@ -116,14 +116,14 @@ class AttributeMapperTest extends UnitTest
 
         $nameId = 'foo@bar.baz';
         $local = [
-            'foo1' => 'bar1',
-            'foo2' => 'bar2',
-            'foo3' => 'bar3',
+            'foo1' => ['bar1'],
+            'foo2' => ['bar2'],
+            'foo3' => ['bar3'],
         ];
         $external = [
-            'baz1' => 'foobar1',
-            'baz2' => 'foobar2',
-            'baz3' => 'foobar3',
+            'baz1' => ['foobar1'],
+            'baz2' => ['foobar2'],
+            'baz3' => ['foobar3'],
         ];
 
         $this->identityProviderFactory->shouldReceive('getAttributeMapping')
@@ -136,6 +136,6 @@ class AttributeMapperTest extends UnitTest
 
         $result = $mappedAttributes->serialize();
 
-        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo3":"foobar1"}}', $result);
+        $this->assertSame('{"nameId":"foo@bar.baz","attributes":{"foo3":["foobar1"]}}', $result);
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Dto/AttributeListDtoTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Dto/AttributeListDtoTest.php
@@ -76,17 +76,18 @@ class AttributeListDtoTest extends UnitTest
         $convertedAttributes = $dto->getAttributeCollection()->getAttributes();
 
         $this->assertCount(3, $dto->getAttributeCollection());
-        $this->assertEquals('John', $convertedAttributes['firstName']->getValue());
-        $this->assertEquals('Doe', $convertedAttributes['lastName']->getValue());
+        $this->assertEquals(['John'], $convertedAttributes['firstName']->getValue());
+        $this->assertEquals(['Doe'], $convertedAttributes['lastName']->getValue());
         $this->assertEquals(['team-a', 'a-team'], $convertedAttributes['isMemberOf']->getValue());
         $this->assertEquals('johndoe.example.com', $dto->getNameId());
     }
 
     public function provideValidAttributes()
     {
-        yield ['foobar', ['foo' => 'bar'], '{"nameId":"foobar","attributes":{"foo":"bar"}}'];
-        yield ['foobar', ['foo' => 'bar', 'foo2' => 2], '{"nameId":"foobar","attributes":{"foo":"bar","foo2":2}}'];
-        yield ['foobar', ['foo' => 'bar', 'foo2' => 'bar2', 'foo3' => 'bar3'], '{"nameId":"foobar","attributes":{"foo":"bar","foo2":"bar2","foo3":"bar3"}}'];
+        yield ['foobar', ['foo' => ['bar']], '{"nameId":"foobar","attributes":{"foo":["bar"]}}'];
+        yield ['foobar', ['foo' => ['bar', 'foo2' => '2']], '{"nameId":"foobar","attributes":{"foo":["bar","2"]}}'];
+        yield ['foobar', ['foo' => ['bar', 'foo2' => 'bar2', 'foo3' => 'bar3']], '{"nameId":"foobar","attributes":{"foo":["bar","bar2","bar3"]}}'];
+        yield ['foobar', ['foo' => ['bar'], 'foo2' => ['bar', 'bar2']], '{"nameId":"foobar","attributes":{"foo":["bar"],"foo2":["bar","bar2"]}}'];
     }
 
     public function provideInvalidAttributes()
@@ -96,6 +97,11 @@ class AttributeListDtoTest extends UnitTest
         yield ['foobar', [['foobar']], 'The $name of an Attribute must be a scalar value'];
         yield ['foobar', [['foo'=>'bar']], 'The $name of an Attribute must be a scalar value'];
         yield ['foobar', ['valid', new stdClass()], 'The $name of an Attribute must be a scalar value'];
+
+        yield ['foobar', ["foobar" => 0], 'The $value of an Attribute must be an array with strings'];
+        yield ['foobar', ["foobar" => "0"], 'The $value of an Attribute must be an array with strings'];
+        yield ['foobar', ["foobar" => [0]], 'The $value of an Attribute must be an array with strings'];
+        yield ['foobar', ["foobar" => [[]]], 'The $value of an Attribute must be an array with strings'];
 
         yield [1, ['foobar'], 'The $nameId in an AttributeListDto must be a string value'];
         yield [false, ['foobar'], 'The $nameId in an AttributeListDto must be a string value'];

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Dto/RemoteVettingProcessDtoTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Dto/RemoteVettingProcessDtoTest.php
@@ -35,8 +35,8 @@ class RemoteVettingProcessDtoTest extends Unittest
      */
     public function a_process_could_be_serialized_and_deserialized($name, $state, $expected)
     {
-        $attributes = new AttributeListDto(['foo' => 'bar'], 'nameId');
-        $expected = sprintf('{"processId":"process id","token":"{\"identityId\":\"identityId\",\"secondFactorId\":\"secondFactorId\"}","state":%s,"attributes":"{\"nameId\":\"nameId\",\"attributes\":{\"foo\":\"bar\"}}","identityProvider":"IRMA"}', json_encode($expected));
+        $attributes = new AttributeListDto(['foo' => ['bar']], 'nameId');
+        $expected = sprintf('{"processId":"process id","token":"{\"identityId\":\"identityId\",\"secondFactorId\":\"secondFactorId\"}","state":%s,"attributes":"{\"nameId\":\"nameId\",\"attributes\":{\"foo\":[\"bar\"]}}","identityProvider":"IRMA"}', json_encode($expected));
 
         $processId = ProcessId::create('process id');
         $token = RemoteVettingTokenDto::create('identityId', 'secondFactorId');

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Encryption/IdentityEncrypterIntegrationTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Encryption/IdentityEncrypterIntegrationTest.php
@@ -105,9 +105,8 @@ KEY;
     public function test_happy_flow()
     {
         $nameId = 'a-random-nameid@something.else';
-        $raw = 'the raw message we could incorporate';
 
-        $data = new AttributeListDto(['email' => 'johndoe@example.com', 'firstName' => 'John'], $nameId, $raw);
+        $data = new AttributeListDto(['email' => ['johndoe@example.com'], 'firstName' => ['John']], $nameId);
         $this->encrypter->encrypt($data->serialize());
 
         $writtenData = $this->writer->getData();
@@ -117,7 +116,7 @@ KEY;
 
         $serialized = json_decode($result, true);
 
-        $this->assertEquals('johndoe@example.com', $serialized['attributes']['email']);
-        $this->assertEquals('John', $serialized['attributes']['firstName']);
+        $this->assertEquals(['johndoe@example.com'], $serialized['attributes']['email']);
+        $this->assertEquals(['John'], $serialized['attributes']['firstName']);
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Encryption/IdentityEncrypterTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Encryption/IdentityEncrypterTest.php
@@ -133,9 +133,8 @@ RSA_PUBLIC_KEY;
             });
 
         $nameId = 'a-random-nameid@something.else';
-        $raw = 'the raw message we could incorporate';
 
-        $data = new AttributeListDto(['email' => 'johndoe@example.com', 'firstName' => 'John'], $nameId, $raw);
+        $data = new AttributeListDto(['email' => ['johndoe@example.com'], 'firstName' => ['John']], $nameId);
         $this->encrypter->encrypt($data->serialize());
 
         // Assert result
@@ -162,7 +161,7 @@ RSA_PUBLIC_KEY;
         $nameId = 'a-random-nameid@something.else';
         $raw = $this->generateRandomString(5000);
 
-        $data = new AttributeListDto(['email' => 'johndoe@example.com', 'firstName' => 'John'], $nameId, $raw);
+        $data = new AttributeListDto(['email' => ['johndoe@example.com'], 'firstName' => ['John']], $nameId, $raw);
         $this->encrypter->encrypt($data->serialize());
 
         // Assert result
@@ -181,7 +180,7 @@ RSA_PUBLIC_KEY;
 
         $nameId = 'a-random-nameid@something.else';
         $raw = 'the raw message we could incorporate';
-        $data = new AttributeListDto(['email' => 'johndoe@example.com', 'firstName' => 'John'], $nameId, $raw);
+        $data = new AttributeListDto(['email' => ['johndoe@example.com'], 'firstName' => ['John']], $nameId, $raw);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid input was provided to the encrypt method');
@@ -200,7 +199,7 @@ RSA_PUBLIC_KEY;
         $nameId = 'a-random-nameid@something.else';
         $raw = 'the raw message we could incorporate';
 
-        $data = new AttributeListDto(['email' => 'johndoe@example.com', 'firstName' => 'John'], $nameId, $raw);
+        $data = new AttributeListDto(['email' => ['johndoe@example.com'], 'firstName' => ['John']], $nameId, $raw);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Reading RSA public key failed');

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Value/AttributeCollectionInterfaceIntegrationTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Value/AttributeCollectionInterfaceIntegrationTest.php
@@ -32,13 +32,13 @@ class AttributeCollectionInterfaceIntegrationTest extends IntegrationTest
     public function test_correct_integration_of_collections()
     {
         $attributes = [
-            'name' => 'John',
-            'lastName' => 'Doe',
-            'shacHomeOrganization' => 'institution-a.example.com'
+            'name' => ['John'],
+            'lastName' => ['Doe'],
+            'shacHomeOrganization' => ['institution-a.example.com']
         ];
 
         $institutionAttributes = new AttributeListDto($attributes, 'johndoe.institution-a.example.com');
-        $remoteVettingAttributes = new AttributeListDto(array_merge($attributes, ['documentNumber' => 1234567890]), 'identifier-at-rv-idp');
+        $remoteVettingAttributes = new AttributeListDto(array_merge($attributes, ['documentNumber' => ["1234567890"]]), 'identifier-at-rv-idp');
 
         $attributeCollection = new AttributeCollection($attributes);
         $attributeMatches = AttributeMatchCollection::fromAttributeCollection($attributeCollection);


### PR DESCRIPTION
Multi value attributes should be allowed in order to be
able to handle external SAML IdP's. According to the SAML
spec this should be allowed.

https://www.pivotaltracker.com/story/show/171571414