### PR TITLE
Move IdentityAggregation to Remote vetting service

### DIFF
--- a/app/config/remote_vetting.yml
+++ b/app/config/remote_vetting.yml
@@ -99,6 +99,7 @@ services:
       $remoteVettingContext: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\RemoteVettingContext'
       $attributeMapper: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\AttributeMapper'
       $identityEncrypter: '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Encryption\IdentityEncrypter'
+      $applicationHelper: '@self_service.service.application'
       $logger: '@logger'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Controller\RemoteVettingController:
@@ -107,7 +108,6 @@ services:
       - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService'
       - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\RemoteVettingViewHelper'
       - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\SamlCalloutHelper'
-      - '@self_service.service.application'
       - '@logger'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Mock\RemoteVetting\MockConfiguration:

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/State/RemoteVettingStateDone.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/State/RemoteVettingStateDone.php
@@ -31,4 +31,9 @@ class RemoteVettingStateDone extends AbstractRemoteVettingState implements Remot
     {
         return $process->getToken();
     }
+
+    public function getAttributes(RemoteVettingProcessDto $process)
+    {
+        return $process->getAttributes();
+    }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeCollectionAggregate.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeCollectionAggregate.php
@@ -18,10 +18,8 @@
 
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value;
 
-use ArrayIterator;
-use IteratorAggregate;
-use JsonSerializable;
 use Surfnet\StepupSelfService\SelfServiceBundle\Assert;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Dto\AttributeListDto;
 
 class AttributeCollectionAggregate implements AttributeCollectionInterface
 {
@@ -44,6 +42,9 @@ class AttributeCollectionAggregate implements AttributeCollectionInterface
         $this->attributeCollections[$name] = $collection;
     }
 
+    /**
+     * @return AttributeListDto[]
+     */
     public function getAttributes()
     {
         $output = [];

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeCollectionInterface.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVetting/Value/AttributeCollectionInterface.php
@@ -18,12 +18,13 @@
 
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value;
 
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Dto\AttributeListDto;
+
 interface AttributeCollectionInterface
 {
     /**
      * Should return the data of the collection in a JSON serializable manner
-     *
-     * @return array
+     * @return AttributeListDto[]
      */
     public function getAttributes();
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVettingService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RemoteVettingService.php
@@ -158,8 +158,8 @@ class RemoteVettingService
         $remoteVettingSource = $this->remoteVettingContext->getIdentityProviderName();
 
         $attributeCollectionAggregate = new AttributeCollectionAggregate();
-        $attributeCollectionAggregate->add('identity-provider-attributes', $localAttributes);
-        $attributeCollectionAggregate->add('remote-vetting-attributes', $this->remoteVettingContext->getAttributes());
+        $attributeCollectionAggregate->add('local-attributes', $localAttributes);
+        $attributeCollectionAggregate->add('remote-attributes', $this->remoteVettingContext->getAttributes());
         $attributeCollectionAggregate->add('matching-results', $attributeMatches);
 
         return new IdentityData(

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Value/AttributeCollectionInterfaceIntegrationTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/RemoteVetting/Value/AttributeCollectionInterfaceIntegrationTest.php
@@ -20,11 +20,9 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Tests\Service\RemoteVettin
 
 use JsonSerializable;
 use PHPUnit_Framework_TestCase as IntegrationTest;
-use stdClass;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Dto\AttributeListDto;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\AttributeCollection;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\AttributeCollectionAggregate;
-use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\AttributeMatch;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\Value\AttributeMatchCollection;
 
 class AttributeCollectionInterfaceIntegrationTest extends IntegrationTest
@@ -44,13 +42,16 @@ class AttributeCollectionInterfaceIntegrationTest extends IntegrationTest
         $attributeMatches = AttributeMatchCollection::fromAttributeCollection($attributeCollection);
 
         $aggregate = new AttributeCollectionAggregate();
-        $aggregate->add('institution-attributes', $institutionAttributes);
-        $aggregate->add('remote-vetting-attributes', $remoteVettingAttributes);
-        $aggregate->add('attributes-matches', $attributeMatches);
+        $aggregate->add('local-attributes', $institutionAttributes);
+        $aggregate->add('remote-attributes', $remoteVettingAttributes);
+        $aggregate->add('attribute-matches', $attributeMatches);
 
         $smashed = $aggregate->getAttributes();
 
         $this->assertTrue($this->isJsonSerializable($smashed));
+        $this->assertArrayHasKey('local-attributes', $smashed);
+        $this->assertArrayHasKey('remote-attributes', $smashed);
+        $this->assertArrayHasKey('attribute-matches', $smashed);
     }
 
     /**


### PR DESCRIPTION
Move the aggregation of the IdentityData to the RemoteVettingService.
That way the controller will keep lightweight and the responsibility
of remote vetting is delegated and only glue is used in the
controller. This resulted in less coupling.

Also the ProviderName is set in the IdentityData, this needed to be
done after the feature was implemented on a different branch.