### PR TITLE
Prevent remote vetting of expired tokens

### DIFF
--- a/app/config/remote_vetting.yml
+++ b/app/config/remote_vetting.yml
@@ -110,6 +110,7 @@ services:
     arguments:
       - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVettingService'
       - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\RemoteVetting\SamlCalloutHelper'
+      - '@surfnet_stepup.registration_expiration_helper'
       - '@logger'
 
   Surfnet\StepupSelfService\SelfServiceBundle\Mock\RemoteVetting\MockConfiguration:

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -65,7 +65,7 @@
                             {% endif %}
                             <td>
                                 <div class="btn-group pull-right" role="group">
-                                    {% if state == 'verified' %}
+                                    {% if state == 'verified' and not expirationHelper.hasExpired(secondFactor.registrationRequestedAt) %}
                                         <a class="btn btn-mini btn-default"
                                            href="{{ path('ss_second_factor_remote_vetting_types', {'secondFactorId': secondFactor.id}) }}">
                                             {{ 'ss.second_factor.revoke.button.remote_vet'|trans }}


### PR DESCRIPTION
Only non expired tokens could be remote vetted. This wasn't fixed
earlier because it came in handy during development.

https://www.pivotaltracker.com/story/show/171571641
https://www.pivotaltracker.com/story/show/171571556

Please review #199 first