### PR TITLE
Use the latest Composer 1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 
 before_script:
   - phpenv config-add .travis.php.ini
-  - composer self-update 1.10.16
+  - composer self-update --1
   - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
   - nvm install 10.22.0
   - curl --compressed -o- -L https://yarnpkg.com/install.sh | bash


### PR DESCRIPTION
Instead of the version pin, the `--1` flag can be used to fetch the latest version 1 of Composer