### PR TITLE
Allow HTML in explanation/description

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/gssf/initiate.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/gssf/initiate.html.twig
@@ -15,7 +15,7 @@
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-    <p>{{ secondFactorConfig.getExplanation() }}</p>
+    <p>{{ secondFactorConfig.getExplanation()|raw }}</p>
 
     <hr>
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/generic_second_factor.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/generic_second_factor.html.twig
@@ -14,7 +14,7 @@
         <hr>
         <p>
             {{
-                (secondFactor.getDescription())|e|replace(
+                (secondFactor.getDescription())|replace(
                 {
                     '%android_link_start%': '<a href="'~appAndroidUrl~'">',
                     '%android_link_end%': '</a>',


### PR DESCRIPTION
This will enable SURF to enrich the description used in emails with
links etc.

See: https://www.pivotaltracker.com/story/show/174901359