### PR TITLE
Catch RV missing context exception

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RemoteVettingController.php
@@ -145,6 +145,7 @@ class RemoteVettingController extends Controller
             return $this->redirectToRoute('ss_second_factor_list');
         } catch (InvalidRemoteVettingContextException $e) {
             $this->logger->error($e->getMessage());
+            $flashBag->add('error', 'ss.second_factor.revoke.alert.remote_vetting_invalid_context');
             return $this->redirectToRoute('ss_second_factor_list');
         }
 
@@ -170,10 +171,10 @@ class RemoteVettingController extends Controller
 
         $localAttributes = AttributeListDto::fromAttributeSet($samlToken->getAttribute(SamlToken::ATTRIBUTE_SET));
 
-        $matches = $this->remoteVettingService->getAttributeMatchCollection($localAttributes);
-        $command = new RemoteVetValidationCommand($matches, new FeedbackCollection());
-
         try {
+            $matches = $this->remoteVettingService->getAttributeMatchCollection($localAttributes);
+            $command = new RemoteVetValidationCommand($matches, new FeedbackCollection());
+
             $form = $this->createForm(RemoteVetValidationType::class, $command)->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
 
@@ -214,6 +215,7 @@ class RemoteVettingController extends Controller
             return $this->redirectToRoute('ss_second_factor_list');
         } catch (InvalidRemoteVettingContextException $e) {
             $this->logger->error($e->getMessage());
+            $flashBag->add('error', 'ss.second_factor.revoke.alert.remote_vetting_invalid_context');
             return $this->redirectToRoute('ss_second_factor_list');
         }
     }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig
@@ -44,6 +44,7 @@
 {# RemoteVettingController flash messages #}
 {{ 'ss.second_factor.revoke.alert.remote_vetting_successful'|trans }}
 {{ 'ss.second_factor.revoke.alert.remote_vetting_failed'|trans }}
+{{  'ss.second_factor.revoke.alert.remote_vetting_invalid_context'|trans }}
 
 {# RemoteVetting Schachomes #}
 {{  'ss.second_factor.remote_vet.schachome.institution-d.example.com'|trans }}

--- a/translations/messages.en_GB.xliff
+++ b/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-02-26T12:48:52Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2021-03-01T16:59:44Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -330,6 +330,11 @@
         <target>Location(s) to activate your token</target>
         <jms:reference-file line="73">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/registration_email_sent.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="7c01f0c80cf83ed8fda6f899a31058df8f20baa2" resname="ss.registration.selector.on-premise.alt">
+        <source>ss.registration.selector.on-premise.alt</source>
+        <target>On premise</target>
+        <jms:reference-file line="30">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="6348b54419006fd2ee31e33581af254358acd8e8" resname="ss.registration.selector.sms.alt">
         <source>ss.registration.selector.sms.alt</source>
         <target>SMS security token</target>
@@ -440,12 +445,13 @@ For all devices with a USB port.</target>
       <trans-unit id="6afeab6302e7089dd152da59ff6167355993e1fd" resname="ss.registration.vetting_type.button.ra_vetting">
         <source>ss.registration.vetting_type.button.ra_vetting</source>
         <target>Continue</target>
-        <jms:reference-file line="33">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="36f60e5402c0f9f29d5167f5448cf08e9b309176" resname="ss.registration.vetting_type.description.ra_vetting">
         <source>ss.registration.vetting_type.description.ra_vetting</source>
         <target>Vet your second factor token at one of your registration authority locations.</target>
-        <jms:reference-file line="31">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8e8386218b7c03203e839b5e6742d008f84d4f2" resname="ss.registration.vetting_type.description.vetting">
         <source>ss.registration.vetting_type.description.vetting</source>
@@ -460,7 +466,7 @@ For all devices with a USB port.</target>
       <trans-unit id="495f21302f01269871f9993f2b8da38bee78fe87" resname="ss.registration.vetting_type.title.ra_vetting">
         <source>ss.registration.vetting_type.title.ra_vetting</source>
         <target>RA vetting</target>
-        <jms:reference-file line="30">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="31">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="51b48a932a70ae43f768348cb7631f248fffd1b1" resname="ss.registration.yubikey.text.connect_yubikey_to_pc">
         <source>ss.registration.yubikey.text.connect_yubikey_to_pc</source>
@@ -519,48 +525,48 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="592e99cfa9d801bcb9a834007b236efb7a8a6a0b" resname="ss.second_factor.remote_vet.attribute.givenName">
         <source>ss.second_factor.remote_vet.attribute.givenName</source>
         <target>Given name</target>
-        <jms:reference-file line="52">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="5d02128f4a87f1b0259373e3b95a08cd53a7d31e" resname="ss.second_factor.remote_vet.attribute.surname">
+      <trans-unit id="8683469b603a69de6d5d5d7eb679856cf1159cb5" resname="ss.second_factor.remote_vet.attribute.surname">
         <source>ss.second_factor.remote_vet.attribute.surname</source>
         <target>Surname</target>
-        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="54">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="06702235a44109d8e0d052b53a1bfb4de60c9ee1" resname="ss.second_factor.remote_vet.attribute_name">
         <source>ss.second_factor.remote_vet.attribute_name</source>
         <target>Name</target>
-        <jms:reference-file line="49">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="50">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c0ad65bef267b1286f21b1b74390563f833bb77c" resname="ss.second_factor.remote_vet.feedback">
         <source>ss.second_factor.remote_vet.feedback</source>
         <target state="new">ss.second_factor.remote_vet.feedback</target>
-        <jms:reference-file line="64">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="65">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bb0dc870c01c67456de79fd0351f228166ed815f" resname="ss.second_factor.remote_vet.is_attribute_valid">
         <source>ss.second_factor.remote_vet.is_attribute_valid</source>
         <target>The attribute is valid</target>
-        <jms:reference-file line="52">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85af9776c41d4d96a56222baeaa6d49ca1e506b5" resname="ss.second_factor.remote_vet.personal_data">
         <source>ss.second_factor.remote_vet.personal_data</source>
         <target state="new">ss.second_factor.remote_vet.personal_data</target>
-        <jms:reference-file line="44">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="45">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="feef08cccc473f54b73861bb3d99e3eb05fd4567" resname="ss.second_factor.remote_vet.remarks">
         <source>ss.second_factor.remote_vet.remarks</source>
         <target>Remarks</target>
         <jms:reference-file line="66">/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetFeedbackType.php</jms:reference-file>
-        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="54">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f81b2c3eb158c91d865540594f516d017f524e8e" resname="ss.second_factor.remote_vet.schachome.institution-d.example.com">
         <source>ss.second_factor.remote_vet.schachome.institution-d.example.com</source>
         <target>Institution D</target>
-        <jms:reference-file line="49">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="50">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="789743faa71a92af3b0c7580952c3a47e62048ac" resname="ss.second_factor.remote_vet.text.does_it_match">
         <source>ss.second_factor.remote_vet.text.does_it_match</source>
         <target>Is the supplied information correct?</target>
-        <jms:reference-file line="35">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c1a0c3ced900e4d33e110a5c2772ca68e85bf0f" resname="ss.second_factor.remote_vet_validation.title">
         <source>ss.second_factor.remote_vet_validation.title</source>
@@ -571,6 +577,11 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
         <source>ss.second_factor.revoke.alert.remote_vetting_failed</source>
         <target>Unable to validate the information</target>
         <jms:reference-file line="46">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="1cd47da8cc4685091dc18566b4276eaf1c7b91e3" resname="ss.second_factor.revoke.alert.remote_vetting_invalid_context">
+        <source>ss.second_factor.revoke.alert.remote_vetting_invalid_context</source>
+        <target>Unable to find an active remote vetting token process</target>
+        <jms:reference-file line="47">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="435098de3a58f8ec3944b674134d917586344aa0" resname="ss.second_factor.revoke.alert.remote_vetting_successful">
         <source>ss.second_factor.revoke.alert.remote_vetting_successful</source>

--- a/translations/messages.nl_NL.xliff
+++ b/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-02-26T12:48:48Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2021-03-01T16:59:39Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -330,6 +330,11 @@
         <target>Locatie(s) om je token te activeren</target>
         <jms:reference-file line="73">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/registration_email_sent.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="7c01f0c80cf83ed8fda6f899a31058df8f20baa2" resname="ss.registration.selector.on-premise.alt">
+        <source>ss.registration.selector.on-premise.alt</source>
+        <target>Op locatie</target>
+        <jms:reference-file line="30">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="6348b54419006fd2ee31e33581af254358acd8e8" resname="ss.registration.selector.sms.alt">
         <source>ss.registration.selector.sms.alt</source>
         <target>SMS-beveiligingstoken</target>
@@ -440,12 +445,13 @@ Geschikt voor alle devices met een USB-poort.</target>
       <trans-unit id="6afeab6302e7089dd152da59ff6167355993e1fd" resname="ss.registration.vetting_type.button.ra_vetting">
         <source>ss.registration.vetting_type.button.ra_vetting</source>
         <target>Verder</target>
-        <jms:reference-file line="33">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="36f60e5402c0f9f29d5167f5448cf08e9b309176" resname="ss.registration.vetting_type.description.ra_vetting">
         <source>ss.registration.vetting_type.description.ra_vetting</source>
         <target>Activeer je token bij een van de RA locaties.</target>
-        <jms:reference-file line="31">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8e8386218b7c03203e839b5e6742d008f84d4f2" resname="ss.registration.vetting_type.description.vetting">
         <source>ss.registration.vetting_type.description.vetting</source>
@@ -460,7 +466,7 @@ Geschikt voor alle devices met een USB-poort.</target>
       <trans-unit id="495f21302f01269871f9993f2b8da38bee78fe87" resname="ss.registration.vetting_type.title.ra_vetting">
         <source>ss.registration.vetting_type.title.ra_vetting</source>
         <target>RA vetting</target>
-        <jms:reference-file line="30">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="31">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="51b48a932a70ae43f768348cb7631f248fffd1b1" resname="ss.registration.yubikey.text.connect_yubikey_to_pc">
         <source>ss.registration.yubikey.text.connect_yubikey_to_pc</source>
@@ -517,54 +523,54 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="592e99cfa9d801bcb9a834007b236efb7a8a6a0b" resname="ss.second_factor.remote_vet.attribute.givenName">
         <source>ss.second_factor.remote_vet.attribute.givenName</source>
         <target>Voornaam</target>
-        <jms:reference-file line="52">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="5d02128f4a87f1b0259373e3b95a08cd53a7d31e" resname="ss.second_factor.remote_vet.attribute.surname">
+      <trans-unit id="8683469b603a69de6d5d5d7eb679856cf1159cb5" resname="ss.second_factor.remote_vet.attribute.surname">
         <source>ss.second_factor.remote_vet.attribute.surname</source>
         <target>Achternaam</target>
-        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="54">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="06702235a44109d8e0d052b53a1bfb4de60c9ee1" resname="ss.second_factor.remote_vet.attribute_name">
         <source>ss.second_factor.remote_vet.attribute_name</source>
         <target>Persoonsgegeven</target>
-        <jms:reference-file line="49">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="50">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c0ad65bef267b1286f21b1b74390563f833bb77c" resname="ss.second_factor.remote_vet.feedback">
         <source>ss.second_factor.remote_vet.feedback</source>
         <target state="new">Over je ervaringen</target>
-        <jms:reference-file line="64">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="65">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bb0dc870c01c67456de79fd0351f228166ed815f" resname="ss.second_factor.remote_vet.is_attribute_valid">
         <source>ss.second_factor.remote_vet.is_attribute_valid</source>
         <target>Komen overeen</target>
-        <jms:reference-file line="52">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85af9776c41d4d96a56222baeaa6d49ca1e506b5" resname="ss.second_factor.remote_vet.personal_data">
         <source>ss.second_factor.remote_vet.personal_data</source>
         <target>Persoonsgegevens</target>
-        <jms:reference-file line="44">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="45">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="feef08cccc473f54b73861bb3d99e3eb05fd4567" resname="ss.second_factor.remote_vet.remarks">
         <source>ss.second_factor.remote_vet.remarks</source>
         <target>Wat wil je verder nog aan ons kwijt?</target>
         <jms:reference-file line="66">/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/RemoteVetFeedbackType.php</jms:reference-file>
-        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="54">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f81b2c3eb158c91d865540594f516d017f524e8e" resname="ss.second_factor.remote_vet.schachome.institution-d.example.com">
         <source>ss.second_factor.remote_vet.schachome.institution-d.example.com</source>
         <target>Instelling D</target>
-        <jms:reference-file line="49">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="50">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="789743faa71a92af3b0c7580952c3a47e62048ac" resname="ss.second_factor.remote_vet.text.does_it_match">
         <source>ss.second_factor.remote_vet.text.does_it_match</source>
-        <target>
+        <target xml:space="preserve">
         Hieronder vind je zowel de identiteitsgegevens die we van je instelling %organization% ontvangen hebben als de identiteitsgegevens die we van %provider% ontvangen hebben. Uiteindelijk willen we het systeem deze identiteitsgegevens automatisch met elkaar laten vergelijken om te bepalen of het om de zelfde persoon gaat en je token te activeren.
 
         Vaak komen gegevens van dezelfde persoon niet helemaal overeen. Daarom vragen we jou om de vergelijking nu zelf te doen en om dingen die jou opvallen in je eigen gegevens te melden zodat wij hiervan kunnen leren. We stellen je ook een aantal vragen over je ervaringen tijdens het gebruik van de deze proof-of-concept van de remote vetting functie van SURFsecureID.
 
         Als je op "bewaar" klikt worden de gegevens die je op dit scherm versleuteld opgeslagen. We gebruiken deze gegevens alleen voor het ontwikkelen en verbeteren van de SURFsecureID en zullen deze aan het einde van de proof of concept, uiterlijk 1-10-2021, vernietigen. Wil je niet dat je gegevens worden bewaard, kies dan voor "Annuleer" of sluit dit scherm.
         </target>
-        <jms:reference-file line="35">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/remote_vetting/validation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c1a0c3ced900e4d33e110a5c2772ca68e85bf0f" resname="ss.second_factor.remote_vet_validation.title">
         <source>ss.second_factor.remote_vet_validation.title</source>
@@ -575,6 +581,11 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
         <source>ss.second_factor.revoke.alert.remote_vetting_failed</source>
         <target>De identiteitsinformatie kon niet worden gevalideerd</target>
         <jms:reference-file line="46">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="1cd47da8cc4685091dc18566b4276eaf1c7b91e3" resname="ss.second_factor.revoke.alert.remote_vetting_invalid_context">
+        <source>ss.second_factor.revoke.alert.remote_vetting_invalid_context</source>
+        <target>Er kon geen actief remote vetting proces gevonden worden</target>
+        <jms:reference-file line="47">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="435098de3a58f8ec3944b674134d917586344aa0" resname="ss.second_factor.revoke.alert.remote_vetting_successful">
         <source>ss.second_factor.revoke.alert.remote_vetting_successful</source>


### PR DESCRIPTION
When during a callout to the remote IdP the session data was expired an
exception was thrown. Now this exception is caught, a flash message is
shown and the enduser gets redirected to the overview page. So the
enduser would be able to try again.