### PR TITLE
Create tag-release.yml

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,64 @@
+name: tag-release
+on:
+  push:
+    tags:
+      - "*.*.*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      COMPONENT_NAME: Stepup-SelfService
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: OpenConext/Stepup-Build
+          ref: master
+      - name: Output the semver tag to the tag variable
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Run release script
+        run: ./stepup-build.sh ${COMPONENT_NAME} --tag ${{ steps.vars.outputs.tag }}
+      - name: Grab the archive filename
+        id: archive
+        run: |
+          echo ::set-output name=archive::$(find . -maxdepth 1 -name "$COMPONENT_NAME*.tar.bz2" -printf '%f\n')
+          echo ::set-output name=shasum::$(find . -maxdepth 1 -name "$COMPONENT_NAME*.sha" -printf '%f\n')
+      - name: Create Draft Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.vars.outputs.tag }}
+          release_name: ${{ steps.vars.outputs.tag }}
+          body: Auto generated release. Please update these release notes manually.
+          draft: true
+          prerelease: false
+      - uses: actions/upload-release-asset@v1.0.1
+        name: Upload the release artefact tarbal
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.archive.outputs.archive }}
+          asset_name: ${{ steps.archive.outputs.archive }}
+          asset_content_type: application/gzip
+      - uses: actions/upload-release-asset@v1.0.1
+        name: Upload the release artefact verification shasum
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.archive.outputs.shasum }}
+          asset_name: ${{ steps.archive.outputs.shasum }}
+          asset_content_type: text/plain
+      - uses: eregon/publish-release@v1
+        name: Publish the new release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ steps.create_release.outputs.id }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 3.5.4
+- Introduce a Github Actions workflow for auto-building tags
+
 ## 3.5.3
 - Added browserlist entry in package.json to ensure IE 11 support
 


### PR DESCRIPTION
This workflow will start a release procedure using Stepup-Build scripts. Resulting in a tarbal and shasum that is uploaded to the github release page