### PR TITLE
Require step up authentication for Recovery Token create and delete actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
   global:
     - APP_ENV=test
 
+dist: bionic
+
 cache:
   directories:
     - ~/.composer

--- a/composer.lock
+++ b/composer.lock
@@ -1163,24 +1163,24 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.7",
+            "version": "6.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "724562fa861e21a4071c652c8a159934e4f05592"
+                "reference": "a52f0440530b54fa079ce76e8c5d196a42cad981"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/724562fa861e21a4071c652c8a159934e4f05592",
-                "reference": "724562fa861e21a4071c652c8a159934e4f05592",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a52f0440530b54fa079ce76e8c5d196a42cad981",
+                "reference": "a52f0440530b54fa079ce76e8c5d196a42cad981",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.6.1",
+                "guzzlehttp/psr7": "^1.9",
                 "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.17.0"
+                "symfony/polyfill-intl-idn": "^1.17"
             },
             "require-dev": {
                 "ext-curl": "*",
@@ -1256,6 +1256,10 @@
                 "rest",
                 "web service"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/6.5.8"
+            },
             "funding": [
                 {
                     "url": "https://github.com/GrahamCampbell",
@@ -1270,7 +1274,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T21:36:50+00:00"
+            "time": "2022-06-20T22:16:07+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1299,12 +1303,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1336,6 +1340,10 @@
             "keywords": [
                 "promise"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.5.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/GrahamCampbell",
@@ -1354,16 +1362,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.5",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "337e3ad8e5716c15f9657bd214d16cc5e69df268"
+                "reference": "e98e3e6d4f86621a9b75f623996e6bbdeb4b9318"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/337e3ad8e5716c15f9657bd214d16cc5e69df268",
-                "reference": "337e3ad8e5716c15f9657bd214d16cc5e69df268",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/e98e3e6d4f86621a9b75f623996e6bbdeb4b9318",
+                "reference": "e98e3e6d4f86621a9b75f623996e6bbdeb4b9318",
                 "shasum": ""
             },
             "require": {
@@ -1384,7 +1392,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -1442,6 +1450,10 @@
                 "uri",
                 "url"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/1.9.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/GrahamCampbell",
@@ -1456,7 +1468,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-20T21:51:18+00:00"
+            "time": "2022-06-20T21:43:03+00:00"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -10089,5 +10101,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenController.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Controller;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\StepupMiddlewareClientBundle\Exception\NotFoundException;
+use Surfnet\StepupSelfService\SelfServiceBundle\Command\PromiseSafeStorePossessionCommand;
+use Surfnet\StepupSelfService\SelfServiceBundle\Command\RevokeRecoveryTokenCommand;
+use Surfnet\StepupSelfService\SelfServiceBundle\Exception\LogicException;
+use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\PromiseSafeStorePossessionType;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SecondFactorService;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenService;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\SafeStoreService;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsRecoveryTokenService;
+use Symfony\Component\HttpFoundation\Request;
+
+class RecoveryTokenController extends Controller
+{
+    use RecoveryTokenControllerTrait;
+    /**
+     * @var RecoveryTokenService
+     */
+    private $recoveryTokenService;
+
+    /**
+     * @var SecondFactorService
+     */
+    private $secondFactorService;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var SafeStoreService
+     */
+    private $safeStoreService;
+
+    /**
+     * @var SmsRecoveryTokenService
+     */
+    private $smsService;
+
+    public function __construct(
+        RecoveryTokenService $recoveryTokenService,
+        SafeStoreService $safeStoreService,
+        SecondFactorService $secondFactorService,
+        SmsRecoveryTokenService $smsService,
+        LoggerInterface $logger
+    ) {
+        $this->recoveryTokenService = $recoveryTokenService;
+        $this->safeStoreService = $safeStoreService;
+        $this->secondFactorService = $secondFactorService;
+        $this->smsService = $smsService;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Recovery Tokens: Select the token type to add
+     * Shows an overview of the available token types for this Identity
+     */
+    public function selectTokenTypeAction()
+    {
+        $this->logger->info('Determining which recovery token are available');
+        $identity = $this->getIdentity();
+        $this->assertMayAddRecoveryToken($identity);
+
+        $availableRecoveryTokens = $this->recoveryTokenService->getRemainingTokenTypes($identity);
+
+        return $this->render(
+            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/select_recovery_token.html.twig',
+            ['availableRecoveryTokens' => $availableRecoveryTokens]
+        );
+    }
+
+    public function newRecoveryTokenAction($secondFactorId)
+    {
+        $this->logger->info('Determining which recovery token are available');
+        $identity = $this->getIdentity();
+        $this->assertSecondFactorInPossession($secondFactorId, $identity);
+        $this->assertNoRecoveryTokens($identity);
+
+        $secondFactor = $this->secondFactorService->findOneVerified($secondFactorId);
+        $availableRecoveryTokens = $this->recoveryTokenService->getRemainingTokenTypes($identity);
+        if ($secondFactor && $secondFactor->type === 'sms') {
+            $this->logger->notice('SMS recovery token type is not allowed as we are vetting a SMS second factor');
+            unset($availableRecoveryTokens['sms']);
+        }
+
+        return $this->render(
+            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/new_recovery_token.html.twig',
+            [
+                'secondFactorId' => $secondFactorId,
+                'availableRecoveryTokens' => $availableRecoveryTokens
+            ]
+        );
+    }
+
+    /**
+     * Reovery Tokens: create a token of safe-store type
+     *
+     * Shows the one-time secret and asks the Identity to store the
+     * password in a safe location.
+     *
+     * Note: A stepup authentication is required to perform this action.
+     */
+    public function createSafeStoreAction(Request $request)
+    {
+        $identity = $this->getIdentity();
+        $this->assertNoRecoveryTokenOfType('safe-store', $identity);
+        $secret = $this->safeStoreService->produceSecret();
+        $command = new PromiseSafeStorePossessionCommand();
+
+        $form = $this->createForm(PromiseSafeStorePossessionType::class, $command)->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $command->secret = $secret;
+            $command->identity = $identity;
+
+            $executionResult = $this->safeStoreService->promisePossession($command);
+            if (!$executionResult->getErrors()) {
+                return $this->redirect(
+                    $this->generateUrl('ss_second_factor_list')
+                );
+            }
+            $this->addFlash('error', 'ss.form.recovery_token.error.error_message');
+        }
+
+        return $this->render(
+            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/create_safe_store.html.twig',
+            [
+                'form' => $form->createView(),
+                'secret' => $secret,
+            ]
+        );
+    }
+
+    /**
+     * Recovery Tokens: Create the SMS recovery token
+     * Step 1: Send an OTP to phone of Identity
+     *
+     * Note: Shares logic with the registration SMS recovery token send challenge action
+     * Note: A stepup authentication is required to perform this action.
+     */
+    public function createSmsAction(Request $request)
+    {
+        return $this->handleSmsChallenge(
+            $request,
+            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/create_sms.html.twig',
+            'ss_recovery_token_prove_sms_possession'
+        );
+    }
+
+    /**
+     * Recovery Tokens: Create the SMS recovery token
+     * Step 2: Process proof of phone possession of Identity
+     *
+     * Note: Shares logic with the registration SMS recovery token send challenge action
+     */
+    public function proveSmsPossessionAction(Request $request)
+    {
+        return $this->handleSmsProofOfPossession(
+            $request,
+            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/sms_prove_possession.html.twig',
+            'ss_second_factor_list'
+        );
+    }
+
+    /**
+     * Recovery Tokens: delete a recovery token
+     *
+     * Regardless of token type, the recovery token in possession of an Identity
+     * is revoked.
+     *
+     * Note: A stepup authentication is required to perform this action.
+     */
+    public function deleteAction(string $recoveryTokenId)
+    {
+        $this->assertRecoveryTokenInPossession($recoveryTokenId, $this->getIdentity());
+        try {
+            $recoveryToken = $this->recoveryTokenService->getRecoveryToken($recoveryTokenId);
+            $command = new RevokeRecoveryTokenCommand();
+            $command->identity = $this->getIdentity();
+            $command->recoveryToken = $recoveryToken;
+            $executionResult = $this->safeStoreService->revokeRecoveryToken($command);
+            if (!empty($executionResult->getErrors())) {
+                $this->addFlash('error', 'ss.form.recovery_token.delete.success');
+                foreach ($executionResult->getErrors() as $error) {
+                    $this->logger->error(sprintf('Recovery Token revocation failed with message: "%s"', $error));
+                }
+                return;
+            }
+        } catch (NotFoundException $e) {
+            throw new LogicException('Identity %s tried to remove an unpossessed recovery token');
+        }
+        $this->addFlash('success', 'ss.form.recovery_token.delete.success');
+        return $this->redirect($this->generateUrl('ss_second_factor_list'));
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenController.php
@@ -331,8 +331,8 @@ class RecoveryTokenController extends Controller
                     $identity->id
                 )
             );
-
-            throw new NotFoundHttpException();
+            $this->addFlash('error', 'ss.recovery_token.step_up.no_tokens_available.failed');
+            return $this->redirect($this->generateUrl('ss_second_factor_list'));
         }
 
         // By requesting LoA 1.5 any relevant token can be tested (LoA self asserted, 2 and 3)

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenControllerTrait.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenControllerTrait.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Controller;
+
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
+use Surfnet\StepupSelfService\SelfServiceBundle\Command\SendRecoveryTokenSmsChallengeCommand;
+use Surfnet\StepupSelfService\SelfServiceBundle\Command\VerifySmsRecoveryTokenChallengeCommand;
+use Surfnet\StepupSelfService\SelfServiceBundle\Exception\LogicException;
+use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\SendSmsChallengeType;
+use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\VerifySmsChallengeType;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsRecoveryTokenService;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsSecondFactorServiceInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ */
+trait RecoveryTokenControllerTrait
+{
+    /**
+     * Send SMS challenge form handler
+     * - One is used during SMS recovery token registration within the vetting flow
+     * - The other is actioned from the recovery token overview on the '/overview' page
+     *
+     * Note fourth param: '$secondFactorId' is optional parameter, only used in the vetting flow scenario
+     */
+    private function handleSmsChallenge(
+        Request $request,
+        string $templateName,
+        string $exitRoute,
+        ?string $secondFactorId = null
+    ): Response {
+        $identity = $this->getIdentity();
+        $this->assertNoRecoveryTokenOfType('sms', $identity);
+        if ($secondFactorId) {
+            $this->assertSecondFactorInPossession($secondFactorId, $identity);
+        }
+        $command = new SendRecoveryTokenSmsChallengeCommand();
+        $form = $this->createForm(SendSmsChallengeType::class, $command)->handleRequest($request);
+        $otpRequestsRemaining = $this->smsService
+            ->getOtpRequestsRemainingCount(SmsSecondFactorServiceInterface::REGISTRATION_SECOND_FACTOR_ID);
+        $maximumOtpRequests = $this->smsService->getMaximumOtpRequestsCount();
+
+        $viewVariables = [
+            'otpRequestsRemaining' => $otpRequestsRemaining,
+            'maximumOtpRequests' => $maximumOtpRequests
+        ];
+
+        if (isset($secondFactorId)) {
+            $viewVariables['secondFactorId'] = $secondFactorId;
+        }
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $command->identity = $identity->id;
+            $command->institution = $identity->institution;
+
+            if ($otpRequestsRemaining === 0) {
+                $this->addFlash('error', 'ss.prove_phone_possession.challenge_request_limit_reached');
+                return array_merge(['form' => $form->createView()], $viewVariables);
+            }
+
+            if ($this->smsService->sendChallenge($command)) {
+                $urlParameter = [];
+                if (isset($secondFactorId)) {
+                    $urlParameter = ['secondFactorId' => $secondFactorId];
+                }
+                return $this->redirect($this->generateUrl($exitRoute, $urlParameter));
+            }
+            $this->addFlash('error', 'ss.form.recovery_token.error.challenge_not_sent_error_message');
+        }
+        return $this->render(
+            $templateName,
+            array_merge(
+                [
+                    'form' => $form->createView(),
+                ],
+                $viewVariables
+            )
+        );
+    }
+
+    /**
+     * Proof of possession of phone form handler
+     *
+     * Note fourth param: '$secondFactorId' is optional parameter, only used in the vetting flow scenario
+     */
+    private function handleSmsProofOfPossession(
+        Request $request,
+        string $templateName,
+        string $exitRoute,
+        ?string $secondFactorId = null
+    ) {
+        if (!$this->smsService->hasSmsVerificationState(SmsRecoveryTokenService::REGISTRATION_RECOVERY_TOKEN_ID)) {
+            $this->get('session')->getFlashBag()->add('notice', 'ss.registration.sms.alert.no_verification_state');
+            return $this->redirectToRoute('ss_recovery_token_sms');
+        }
+        $identity = $this->getIdentity();
+        $this->assertNoRecoveryTokenOfType('sms', $identity);
+
+        if ($secondFactorId) {
+            $this->assertSecondFactorInPossession($secondFactorId, $identity);
+        }
+
+        $command = new VerifySmsRecoveryTokenChallengeCommand();
+        $command->identity = $identity->id;
+        $command->resendRoute = 'ss_recovery_token_sms';
+
+        $form = $this->createForm(VerifySmsChallengeType::class, $command)->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $result = $this->smsService->provePossession($command);
+            if ($result->isSuccessful()) {
+                $this->smsService->clearSmsVerificationState(SmsRecoveryTokenService::REGISTRATION_RECOVERY_TOKEN_ID);
+                $urlParameter = [];
+                if (isset($secondFactorId)) {
+                    $urlParameter = ['secondFactorId' => $secondFactorId];
+                }
+                return $this->redirect($this->generateUrl($exitRoute, $urlParameter));
+            } elseif ($result->wasIncorrectChallengeResponseGiven()) {
+                $this->addFlash('error', 'ss.prove_phone_possession.incorrect_challenge_response');
+            } elseif ($result->hasChallengeExpired()) {
+                $this->addFlash('error', 'ss.prove_phone_possession.challenge_expired');
+            } elseif ($result->wereTooManyAttemptsMade()) {
+                $this->addFlash('error', 'ss.prove_phone_possession.too_many_attempts');
+            } else {
+                $this->addFlash('error', 'ss.prove_phone_possession.proof_of_possession_failed');
+            }
+        }
+
+        return $this->render(
+            $templateName,
+            [
+                'form' => $form->createView(),
+            ]
+        );
+    }
+
+    private function assertRecoveryTokenInPossession(string $recoveryTokenId, Identity $identity)
+    {
+        $recoveryTokens = $this->recoveryTokenService->getRecoveryTokensForIdentity($identity);
+        $found = false;
+        foreach ($recoveryTokens as $recoveryToken) {
+            if ($recoveryToken->recoveryTokenId === $recoveryTokenId) {
+                $found = true;
+            }
+        }
+        if (!$found) {
+            throw new LogicException(
+                sprintf(
+                    'Identity "%s" tried to perform a self-asserted token registration with a ' .
+                    'recovery token ("%s)", but does not own that recovery token',
+                    $identity->id,
+                    $recoveryTokenId
+                )
+            );
+        }
+    }
+
+    private function assertNoRecoveryTokens(Identity $identity)
+    {
+        if ($this->recoveryTokenService->hasRecoveryToken($identity)) {
+            throw new LogicException(
+                sprintf(
+                    'Identity "%s" tried to register a recovery token, but one was already in possession. ' .
+                    'This is not allowed during self-asserted token registration.',
+                    $identity->id
+                )
+            );
+        }
+    }
+
+    private function assertNoRecoveryTokenOfType(string $type, Identity $identity)
+    {
+        $tokens = $this->recoveryTokenService->getRecoveryTokensForIdentity($identity);
+        if (array_key_exists($type, $tokens)) {
+            throw new LogicException(
+                sprintf(
+                    'Identity "%s" tried to register a recovery token, but one was already in possession. ' .
+                    'This is not allowed during token registration.',
+                    $identity->id
+                )
+            );
+        }
+    }
+
+    private function assertMayAddRecoveryToken(Identity $identity)
+    {
+        $availableTypes = $this->recoveryTokenService->getRemainingTokenTypes($identity);
+        if (count($availableTypes) === 0) {
+            throw new LogicException(
+                sprintf(
+                    'Identity %s tried to register a token type, but all available token types have ' .
+                    'already been registered',
+                    $identity
+                )
+            );
+        }
+    }
+
+    private function assertSecondFactorInPossession(string $secondFactorId, Identity $identity)
+    {
+        $identityOwnsSecondFactor = $this->secondFactorService->identityHasSecondFactorOfStateWithId(
+            $identity->id,
+            'verified',
+            $secondFactorId
+        );
+
+        if (!$identityOwnsSecondFactor) {
+            throw new LogicException(
+                sprintf(
+                    'Identity "%s" tried to register recovery token during registration ' .
+                    'of second factor token "%s", but does not own that second factor',
+                    $identity->id,
+                    $secondFactorId
+                )
+            );
+        }
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SamlController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SamlController.php
@@ -22,6 +22,7 @@ use Exception;
 use Surfnet\SamlBundle\Http\XMLResponse;
 use Surfnet\SamlBundle\SAML2\Response\Assertion\InResponseTo;
 use Surfnet\StepupBundle\Value\Loa;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenState;
 use Surfnet\StepupSelfService\SelfServiceBundle\Value\SelfVetRequestId;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -79,59 +80,65 @@ class SamlController extends Controller
         $logger = $this->get('logger');
 
         $session = $this->get('session');
-        // The test authentication IdP is also used for self vetting, a different session id is
-        // used to mark a self vet command
-        if ($session->has(SelfVetController::SELF_VET_SESSION_ID)) {
-            /** @var SelfVetRequestId $selfVetRequestId */
-            $selfVetRequestId = $session->get(SelfVetController::SELF_VET_SESSION_ID);
-            $secondFactorId = $selfVetRequestId->vettingSecondFactorId();
-            return $this->forward(
-                'SurfnetStepupSelfServiceSelfServiceBundle:SelfVet:consumeSelfVetAssertion',
-                ['secondFactorId' => $secondFactorId]
-            );
-        }
-        if (!$session->has('second_factor_test_request_id')) {
-            $logger->error(
-                'Received an authentication response for testing a second factor, but no second factor test response was expected'
-            );
-
-            throw new AccessDeniedHttpException('Did not expect an authentication response');
-        }
-
-        $logger->notice('Received an authentication response for testing a second factor');
-
-        $initiatedRequestId = $session->get('second_factor_test_request_id');
-
-        $samlLogger = $this->get('surfnet_saml.logger')->forAuthentication($initiatedRequestId);
-
-        $session->remove('second_factor_test_request_id');
-
-        $postBinding = $this->get('surfnet_saml.http.post_binding');
-
-        try {
-            $assertion = $postBinding->processResponse(
-                $httpRequest,
-                $this->get('self_service.second_factor_test_idp'),
-                $this->get('surfnet_saml.hosted.service_provider')
-            );
-
-            if (!InResponseTo::assertEquals($assertion, $initiatedRequestId)) {
-                $samlLogger->error(
-                    sprintf(
-                        'Expected a response to the request with ID "%s", but the SAMLResponse was a response to a different request',
-                        $initiatedRequestId
-                    )
+        switch (true) {
+            case ($session->has(SelfVetController::SELF_VET_SESSION_ID)):
+                // The test authentication IdP is also used for self vetting, a different session id is
+                // used to mark a self vet command
+                /** @var SelfVetRequestId $selfVetRequestId */
+                $selfVetRequestId = $session->get(SelfVetController::SELF_VET_SESSION_ID);
+                $secondFactorId = $selfVetRequestId->vettingSecondFactorId();
+                return $this->forward(
+                    'SurfnetStepupSelfServiceSelfServiceBundle:SelfVet:consumeSelfVetAssertion',
+                    ['secondFactorId' => $secondFactorId]
                 );
+            case ($session->has(RecoveryTokenState::RECOVERY_TOKEN_STEP_UP_REQUEST_ID_IDENTIFIER)):
+                // The test authentication IdP is also used for self-asserted recovery token
+                // verification a different session id is used to mark the authentication.
+                return $this->forward('SurfnetStepupSelfServiceSelfServiceBundle:RecoveryToken:stepUpConsumeAssertion');
+            default:
+                if (!$session->has('second_factor_test_request_id')) {
+                    $logger->error(
+                        'Received an authentication response for testing a second factor, but no second factor test response was expected'
+                    );
 
-                throw new AuthenticationException('Unexpected InResponseTo in SAMLResponse');
-            }
+                    throw new AccessDeniedHttpException('Did not expect an authentication response');
+                }
 
-            $session->getFlashBag()->add('success', 'ss.test_second_factor.verification_successful');
-        } catch (Exception $exception) {
-            $session->getFlashBag()->add('error', 'ss.test_second_factor.verification_failed');
+                $logger->notice('Received an authentication response for testing a second factor');
+
+                $initiatedRequestId = $session->get('second_factor_test_request_id');
+
+                $samlLogger = $this->get('surfnet_saml.logger')->forAuthentication($initiatedRequestId);
+
+                $session->remove('second_factor_test_request_id');
+
+                $postBinding = $this->get('surfnet_saml.http.post_binding');
+
+                try {
+                    $assertion = $postBinding->processResponse(
+                        $httpRequest,
+                        $this->get('self_service.second_factor_test_idp'),
+                        $this->get('surfnet_saml.hosted.service_provider')
+                    );
+
+                    if (!InResponseTo::assertEquals($assertion, $initiatedRequestId)) {
+                        $samlLogger->error(
+                            sprintf(
+                                'Expected a response to the request with ID "%s", but the SAMLResponse was a response to a different request',
+                                $initiatedRequestId
+                            )
+                        );
+
+                        throw new AuthenticationException('Unexpected InResponseTo in SAMLResponse');
+                    }
+
+                    $session->getFlashBag()->add('success', 'ss.test_second_factor.verification_successful');
+                } catch (Exception $exception) {
+                    $session->getFlashBag()->add('error', 'ss.test_second_factor.verification_failed');
+                }
+
+                return $this->redirectToRoute('ss_second_factor_list');
         }
-
-        return $this->redirectToRoute('ss_second_factor_list');
     }
 
     public function metadataAction()

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SamlController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SamlController.php
@@ -60,10 +60,10 @@ class SamlController extends Controller
 
         $authenticationRequestFactory = $this->get('self_service.test_second_factor_authentication_request_factory');
 
-        // By requesting LoA 2 any relevant token can be tested (LoA 2 and 3)
+        // By requesting LoA 1.5 any relevant token can be tested (LoA 2 and 3)
         $authenticationRequest = $authenticationRequestFactory->createSecondFactorTestRequest(
             $identity->nameId,
-            $loaResolutionService->getLoaByLevel(Loa::LOA_2)
+            $loaResolutionService->getLoaByLevel(Loa::LOA_1_5)
         );
 
         $this->get('session')->set('second_factor_test_request_id', $authenticationRequest->getRequestId());

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfAssertedTokensController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfAssertedTokensController.php
@@ -19,39 +19,32 @@
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Controller;
 
 use Psr\Log\LoggerInterface;
+use Surfnet\StepupBundle\Service\LoaResolutionService;
+use Surfnet\StepupBundle\Service\SmsRecoveryTokenService;
 use Surfnet\StepupBundle\Value\PhoneNumber\InternationalPhoneNumber;
-use Surfnet\StepupMiddlewareClientBundle\Exception\NotFoundException;
-use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\PromiseSafeStorePossessionCommand;
-use Surfnet\StepupSelfService\SelfServiceBundle\Command\RevokeRecoveryTokenCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\SafeStoreAuthenticationCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\SelfAssertedTokenRegistrationCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\SendRecoveryTokenSmsAuthenticationChallengeCommand;
-use Surfnet\StepupSelfService\SelfServiceBundle\Command\SendRecoveryTokenSmsChallengeCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\VerifySmsRecoveryTokenChallengeCommand;
-use Surfnet\StepupSelfService\SelfServiceBundle\Exception\LogicException;
 use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\AuthenticateSafeStoreType;
 use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\PromiseSafeStorePossessionType;
-use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\SendSmsChallengeType;
 use Surfnet\StepupSelfService\SelfServiceBundle\Form\Type\VerifySmsChallengeType;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SecondFactorService;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\AuthenticationRequestFactory;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenService;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\SafeStoreService;
-use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsRecoveryTokenService;
-use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsSecondFactorService;
-use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsSecondFactorServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @SuppressWarnings(PHPMD.TooManyPublicMethods) - Could be resolved by moving the non registration actions to a
- * controller of it's own.
- * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) - Controller logic is known to have high complexity.
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects) - The controller interacts with several services, resulting in high
- * coupling.
+ *
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class SelfAssertedTokensController extends Controller
 {
+    use RecoveryTokenControllerTrait;
     /**
      * @var RecoveryTokenService
      */
@@ -77,11 +70,23 @@ class SelfAssertedTokensController extends Controller
      */
     private $smsService;
 
+    /**
+     * @var LoaResolutionService
+     */
+    private $loaResolutionService;
+
+    /**
+     * @var AuthenticationRequestFactory
+     */
+    private $authnRequestFactory;
+
     public function __construct(
         RecoveryTokenService $recoveryTokenService,
         SafeStoreService $safeStoreService,
         SecondFactorService $secondFactorService,
         SmsRecoveryTokenService $smsService,
+        LoaResolutionService $loaResolutionService,
+        AuthenticationRequestFactory $authenticationRequestFactory,
         LoggerInterface $logger
     ) {
         $this->recoveryTokenService = $recoveryTokenService;
@@ -89,13 +94,18 @@ class SelfAssertedTokensController extends Controller
         $this->secondFactorService = $secondFactorService;
         $this->smsService = $smsService;
         $this->logger = $logger;
+        $this->loaResolutionService = $loaResolutionService;
+        $this->authnRequestFactory = $authenticationRequestFactory;
     }
 
     /**
-     * Select(s) the recovery token to perform the self-asserted second factor token registration with.
+     * Self-asserted token registration: Registration entrypoint
+     *
+     * Select(s) the recovery token to perform the self-asserted second factor
+     * token registration with.
      *
      * Possible outcomes:
-     * 1. Shows a recovery token selection screen when more than one tokens are available
+     * 1. Shows a recovery token selection screen when more than one token are available
      * 2. Selects the one and only available recovery token and redirects to the recovery token authentication route
      * 3. Starts registration of a recovery token if non are in possession
      */
@@ -141,8 +151,13 @@ class SelfAssertedTokensController extends Controller
     }
 
     /**
+     * Self-asserted token registration: Authenticate recovery token
+     *
      * Identity must authenticate the recovery token in order to perform a
-     * self-asserted token registration.
+     * self-asserted token registration. But only when this action is
+     * performed while recovering a Second Factor token. During initial
+     * registration of a recovery token in the self-asserted token registration
+     * flow, authentication is not required.
      */
     public function selfAssertedTokenRegistrationRecoveryTokenAction(
         Request $request,
@@ -157,6 +172,7 @@ class SelfAssertedTokensController extends Controller
 
         switch ($token->type) {
             case "sms":
+                // Todo skip authentication when recovery token is already in possession.
                 $number = InternationalPhoneNumber::fromStringFormat($token->identifier);
                 $command = new SendRecoveryTokenSmsAuthenticationChallengeCommand();
                 $command->identifier = $number;
@@ -203,6 +219,13 @@ class SelfAssertedTokensController extends Controller
         }
     }
 
+    /**
+     * Self-asserted token registration: Authenticate a SMS recovery token
+     *
+     * The previous action (selfAssertedTokenRegistrationRecoveryTokenAction)
+     * sent the Identity a OTP via SMS. The Identity must reproduce that OTP
+     * in this action. Proving possession of the recovery token.
+     */
     public function selfAssertedTokenRecoveryTokenSmsAuthenticationAction(
         Request $request,
         string $secondFactorId,
@@ -262,6 +285,13 @@ class SelfAssertedTokensController extends Controller
         );
     }
 
+    /**
+     * Self-asserted token registration: choose recovery token type
+     *
+     * The user can select which recovery token to add. Some limitations may
+     * apply. For example, using a SMS Recovery Token for registration of an
+     * SMS Second Factor is only allowed when different phone numbers are used.
+     */
     public function newRecoveryTokenAction($secondFactorId)
     {
         $this->logger->info('Determining which recovery token are available');
@@ -285,20 +315,12 @@ class SelfAssertedTokensController extends Controller
         );
     }
 
-    public function selectTokenTypeAction()
-    {
-        $this->logger->info('Determining which recovery token are available');
-        $identity = $this->getIdentity();
-        $this->assertMayAddRecoveryToken($identity);
-
-        $availableRecoveryTokens = $this->recoveryTokenService->getRemainingTokenTypes($identity);
-
-        return $this->render(
-            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/select_recovery_token.html.twig',
-            ['availableRecoveryTokens' => $availableRecoveryTokens]
-        );
-    }
-
+    /**
+     * Self-asserted token registration: Create Recovery Token (safe-store)
+     *
+     * Shows the one-time secret and asks the Identity to store the
+     * password in a safe location.
+     */
     public function registerCreateRecoveryTokenSafeStoreAction(Request $request, $secondFactorId)
     {
         $identity = $this->getIdentity();
@@ -333,6 +355,12 @@ class SelfAssertedTokensController extends Controller
         );
     }
 
+    /**
+     * Self-asserted token registration: Create the SMS recovery token
+     * Step 1: Send an OTP to phone of Identity
+     *
+     * Note: Shares logic with the recovery token SMS send challenge action
+     */
     public function registerRecoveryTokenSmsAction(Request $request, string $secondFactorId)
     {
         return $this->handleSmsChallenge(
@@ -343,6 +371,12 @@ class SelfAssertedTokensController extends Controller
         );
     }
 
+    /**
+     * Self-asserted token registration: Create the SMS recovery token
+     * Step 2: Process proof of phone possession of Identity
+     *
+     * Note: Shares logic with the recovery token SMS send challenge action
+     */
     public function registerRecoveryTokenSmsProofOfPossessionAction(Request $request, string $secondFactorId)
     {
         return $this->handleSmsProofOfPossession(
@@ -350,266 +384,6 @@ class SelfAssertedTokensController extends Controller
             '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/registration_sms_prove_possession.html.twig',
             'ss_second_factor_self_asserted_tokens',
             $secondFactorId
-        );
-    }
-
-    public function createSafeStoreAction(Request $request)
-    {
-        $identity = $this->getIdentity();
-        $this->assertNoRecoveryTokenOfType('safe-store', $identity);
-        $secret = $this->safeStoreService->produceSecret();
-        $command = new PromiseSafeStorePossessionCommand();
-
-        $form = $this->createForm(PromiseSafeStorePossessionType::class, $command)->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $command->secret = $secret;
-            $command->identity = $identity;
-
-            $executionResult = $this->safeStoreService->promisePossession($command);
-            if (!$executionResult->getErrors()) {
-                return $this->redirect(
-                    $this->generateUrl('ss_second_factor_list')
-                );
-            }
-            $this->addFlash('error', 'ss.form.recovery_token.error.error_message');
-        }
-
-        return $this->render(
-            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/create_safe_store.html.twig',
-            [
-                'form' => $form->createView(),
-                'secret' => $secret,
-            ]
-        );
-    }
-
-    public function createSmsAction(Request $request)
-    {
-        return $this->handleSmsChallenge(
-            $request,
-            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/create_sms.html.twig',
-            'ss_recovery_token_prove_sms_possession'
-        );
-    }
-
-    public function proveSmsPossessionAction(Request $request)
-    {
-        return $this->handleSmsProofOfPossession(
-            $request,
-            '@SurfnetStepupSelfServiceSelfService/registration/self_asserted_tokens/sms_prove_possession.html.twig',
-            'ss_second_factor_list'
-        );
-    }
-
-    public function deleteAction(string $recoveryTokenId)
-    {
-        try {
-            $recoveryToken = $this->recoveryTokenService->getRecoveryToken($recoveryTokenId);
-            $command = new RevokeRecoveryTokenCommand();
-            $command->identity = $this->getIdentity();
-            $command->recoveryToken = $recoveryToken;
-            $executionResult = $this->safeStoreService->revokeRecoveryToken($command);
-            if (!empty($executionResult->getErrors())) {
-                $this->addFlash('error', 'ss.form.recovery_token.delete.success');
-                foreach ($executionResult->getErrors() as $error) {
-                    $this->logger->error(sprintf('Recovery Token revocation failed with message: "%s"', $error));
-                }
-                return;
-            }
-        } catch (NotFoundException $e) {
-            throw new LogicException('Identity %s tried to remove an unpossessed recovery token');
-        }
-        $this->addFlash('success', 'ss.form.recovery_token.delete.success');
-        return $this->redirect($this->generateUrl('ss_second_factor_list'));
-    }
-
-    private function assertSecondFactorInPossession(string $secondFactorId, Identity $identity)
-    {
-        $identityOwnsSecondFactor = $this->secondFactorService->identityHasSecondFactorOfStateWithId(
-            $identity->id,
-            'verified',
-            $secondFactorId
-        );
-
-        if (!$identityOwnsSecondFactor) {
-            throw new LogicException(
-                sprintf(
-                    'Identity "%s" tried to register recovery token during registration ' .
-                    'of second factor token "%s", but does not own that second factor',
-                    $identity->id,
-                    $secondFactorId
-                )
-            );
-        }
-    }
-
-    private function assertRecoveryTokenInPossession(string $recoveryTokenId, Identity $identity)
-    {
-        $recoveryTokens = $this->recoveryTokenService->getRecoveryTokensForIdentity($identity);
-        $found = false;
-        foreach ($recoveryTokens as $recoveryToken) {
-            if ($recoveryToken->recoveryTokenId === $recoveryTokenId) {
-                $found = true;
-            }
-        }
-        if (!$found) {
-            throw new LogicException(
-                sprintf(
-                    'Identity "%s" tried to perform a self-asserted token registration with a ' .
-                    'recovery token ("%s)", but does not own that recovery token',
-                    $identity->id,
-                    $recoveryTokenId
-                )
-            );
-        }
-    }
-
-    private function assertNoRecoveryTokens(Identity $identity)
-    {
-        if ($this->recoveryTokenService->hasRecoveryToken($identity)) {
-            throw new LogicException(
-                sprintf(
-                    'Identity "%s" tried to register a recovery token, but one was already in possession. ' .
-                    'This is not allowed during self-asserted token registration.',
-                    $identity->id
-                )
-            );
-        }
-    }
-
-    private function assertNoRecoveryTokenOfType(string $type, Identity $identity)
-    {
-        $tokens = $this->recoveryTokenService->getRecoveryTokensForIdentity($identity);
-        if (array_key_exists($type, $tokens)) {
-            throw new LogicException(
-                sprintf(
-                    'Identity "%s" tried to register a recovery token, but one was already in possession. ' .
-                    'This is not allowed during token registration.',
-                    $identity->id
-                )
-            );
-        }
-    }
-
-    private function assertMayAddRecoveryToken(Identity $identity)
-    {
-        $availableTypes = $this->recoveryTokenService->getRemainingTokenTypes($identity);
-        if (count($availableTypes) === 0) {
-            throw new LogicException(
-                sprintf(
-                    'Identity %s tried to register a token type, but all available token types have ' .
-                    'already been registered',
-                    $identity
-                )
-            );
-        }
-    }
-
-    /**
-     * Shared Send SMS challenge form handler
-     * - One is used during SMS recovery token registration within the vetting flow
-     * - The other is actioned from the recovery token overview on the '/overview' page
-     *
-     * Note fourth param: '$secondFactorId' is optional parameter, only used in the vetting flow scenario
-     */
-    private function handleSmsChallenge(
-        Request $request,
-        string $templateName,
-        string $exitRoute,
-        ?string $secondFactorId = null
-    ): Response {
-        $identity = $this->getIdentity();
-        $this->assertNoRecoveryTokenOfType('sms', $identity);
-        $command = new SendRecoveryTokenSmsChallengeCommand();
-        $form = $this->createForm(SendSmsChallengeType::class, $command)->handleRequest($request);
-        /** @var SmsSecondFactorService $service */
-        $otpRequestsRemaining = $this->smsService
-            ->getOtpRequestsRemainingCount(SmsSecondFactorServiceInterface::REGISTRATION_SECOND_FACTOR_ID);
-        $maximumOtpRequests = $this->smsService->getMaximumOtpRequestsCount();
-
-        $viewVariables = [
-            'otpRequestsRemaining' => $otpRequestsRemaining,
-            'maximumOtpRequests' => $maximumOtpRequests
-        ];
-
-        if (isset($secondFactorId)) {
-            $viewVariables['secondFactorId'] = $secondFactorId;
-        }
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $command->identity = $identity->id;
-            $command->institution = $identity->institution;
-
-            if ($otpRequestsRemaining === 0) {
-                $this->addFlash('error', 'ss.prove_phone_possession.challenge_request_limit_reached');
-                return array_merge(['form' => $form->createView()], $viewVariables);
-            }
-
-            if ($this->smsService->sendChallenge($command)) {
-                $urlParameter = [];
-                if (isset($secondFactorId)) {
-                    $urlParameter = ['secondFactorId' => $secondFactorId];
-                }
-                return $this->redirect($this->generateUrl($exitRoute, $urlParameter));
-            }
-            $this->addFlash('error', 'ss.form.recovery_token.error.error_message');
-        }
-        return $this->render(
-            $templateName,
-            array_merge(
-                [
-                    'form' => $form->createView(),
-                ],
-                $viewVariables
-            )
-        );
-    }
-
-    private function handleSmsProofOfPossession(
-        Request $request,
-        string $templateName,
-        string $exitRoute,
-        ?string $secondFactorId = null
-    ) {
-        if (!$this->smsService->hasSmsVerificationState(SmsRecoveryTokenService::REGISTRATION_RECOVERY_TOKEN_ID)) {
-            $this->get('session')->getFlashBag()->add('notice', 'ss.registration.sms.alert.no_verification_state');
-            return $this->redirectToRoute('ss_recovery_token_sms');
-        }
-        $identity = $this->getIdentity();
-        $this->assertNoRecoveryTokenOfType('sms', $identity);
-
-        $command = new VerifySmsRecoveryTokenChallengeCommand();
-        $command->identity = $identity->id;
-        $command->resendRoute = 'ss_recovery_token_sms';
-
-        $form = $this->createForm(VerifySmsChallengeType::class, $command)->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $result = $this->smsService->provePossession($command);
-            if ($result->isSuccessful()) {
-                $this->smsService->clearSmsVerificationState(SmsRecoveryTokenService::REGISTRATION_RECOVERY_TOKEN_ID);
-                $urlParameter = [];
-                if (isset($secondFactorId)) {
-                    $urlParameter = ['secondFactorId' => $secondFactorId];
-                }
-                return $this->redirect($this->generateUrl($exitRoute, $urlParameter));
-            } elseif ($result->wasIncorrectChallengeResponseGiven()) {
-                $this->addFlash('error', 'ss.prove_phone_possession.incorrect_challenge_response');
-            } elseif ($result->hasChallengeExpired()) {
-                $this->addFlash('error', 'ss.prove_phone_possession.challenge_expired');
-            } elseif ($result->wereTooManyAttemptsMade()) {
-                $this->addFlash('error', 'ss.prove_phone_possession.too_many_attempts');
-            } else {
-                $this->addFlash('error', 'ss.prove_phone_possession.proof_of_possession_failed');
-            }
-        }
-
-        return $this->render(
-            $templateName,
-            [
-                'form' => $form->createView(),
-            ]
         );
     }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
@@ -35,6 +35,31 @@ ss_second_factor_self_vet_consume_assertion:
     methods:  [POST]
     defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:SelfVet:consumeSelfVetAssertion }
 
+ss_recovery_token_display_types:
+    path: /recovery-token/select-recovery-token
+    methods: [GET]
+    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:RecoveryToken:selectTokenType }
+
+ss_recovery_token_safe_store:
+    path: /recovery-token/create-safe-store
+    methods: [GET, POST]
+    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:RecoveryToken:createSafeStore }
+
+ss_recovery_token_delete:
+    path: /recovery-token/delete/{recoveryTokenId}
+    methods: [GET]
+    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:RecoveryToken:delete }
+
+ss_recovery_token_sms:
+    path: /recovery-token/create-sms
+    methods: [GET, POST]
+    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:RecoveryToken:createSms }
+
+ss_recovery_token_prove_sms_possession:
+    path: /recovery-token/prove-sms-possession
+    methods: [GET, POST]
+    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:RecoveryToken:proveSmsPossession }
+
 ss_second_factor_self_asserted_tokens:
     path:     /second-factor/{secondFactorId}/self-asserted-token-registration
     methods:  [GET]
@@ -59,31 +84,6 @@ ss_registration_recovery_token_safe_store:
     path:     /second-factor/{secondFactorId}/safe-store
     methods:  [GET,POST]
     defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:SelfAssertedTokens:registerCreateRecoveryTokenSafeStore }
-
-ss_recovery_token_display_types:
-    path: /recovery-token/select-recovery-token
-    methods: [GET]
-    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:SelfAssertedTokens:selectTokenType }
-
-ss_recovery_token_safe_store:
-    path: /recovery-token/create-safe-store
-    methods: [GET, POST]
-    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:SelfAssertedTokens:createSafeStore }
-
-ss_recovery_token_delete:
-    path: /recovery-token/delete/{recoveryTokenId}
-    methods: [GET]
-    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:SelfAssertedTokens:delete }
-
-ss_recovery_token_sms:
-    path: /recovery-token/create-sms
-    methods: [GET, POST]
-    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:SelfAssertedTokens:createSms }
-
-ss_recovery_token_prove_sms_possession:
-    path: /recovery-token/prove-sms-possession
-    methods: [GET, POST]
-    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:SelfAssertedTokens:proveSmsPossession }
 
 ss_registration_recovery_token_sms:
     path:     /second-factor/{secondFactorId}/sms

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -104,7 +104,7 @@ services:
             - '@Surfnet\StepupBundle\Service\SmsRecoveryTokenService'
             - "@translator"
             - "@surfnet_stepup_self_service_self_service.service.command"
-            -
+
     surfnet_stepup_self_service_self_service.service.gssf:
         class: Surfnet\StepupSelfService\SelfServiceBundle\Service\GssfService
         arguments:
@@ -184,6 +184,11 @@ services:
         arguments:
             - '@surfnet_saml.hosted.service_provider'
             - '@self_service.second_factor_test_idp'
+
+    Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\AuthenticationRequestFactory:
+        arguments:
+            - "@surfnet_saml.hosted.service_provider"
+            - "@self_service.recovery_token_step_up_idp"
 
     self_service.event_listener.locale:
         class: Surfnet\StepupSelfService\SelfServiceBundle\EventListener\LocaleListener

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -27,6 +27,21 @@ services:
             - "@session"
             - "@logger"
 
+    Surfnet\StepupSelfService\SelfServiceBundle\Controller\RecoveryTokenController:
+        arguments:
+            - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenService'
+            - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\SafeStoreService'
+            - '@surfnet_stepup_self_service_self_service.service.second_factor'
+            - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsRecoveryTokenService'
+            - '@surfnet_stepup.service.loa_resolution'
+            - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\AuthenticationRequestFactory'
+            - '@surfnet_saml.http.redirect_binding'
+            - '@surfnet_saml.http.post_binding'
+            - '@surfnet_saml.hosted.service_provider'
+            - '@self_service.second_factor_test_idp'
+            - '@surfnet_saml.logger'
+            - '@logger'
+
     surfnet_stepup_self_service_self_service.service.command:
         class: Surfnet\StepupSelfService\SelfServiceBundle\Service\CommandService
         arguments:
@@ -128,9 +143,14 @@ services:
         arguments:
             - '@Surfnet\StepupMiddlewareClientBundle\Identity\Service\RecoveryTokenService'
             - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\SafeStoreService'
+            - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenState'
             - '@logger'
 
     Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\SafeStoreState:
+        arguments:
+            - '@session'
+
+    Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenState:
         arguments:
             - '@session'
 
@@ -188,7 +208,7 @@ services:
     Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\AuthenticationRequestFactory:
         arguments:
             - "@surfnet_saml.hosted.service_provider"
-            - "@self_service.recovery_token_step_up_idp"
+            - "@self_service.second_factor_test_idp"
 
     self_service.event_listener.locale:
         class: Surfnet\StepupSelfService\SelfServiceBundle\EventListener\LocaleListener

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig
@@ -52,8 +52,12 @@
 {{ 'ss.form.recovery_token.delete.failed'|trans  }}
 {{ 'ss.self_asserted_tokens.safe_store.authentication.alert.failed'|trans  }}
 {{ 'ss.self_asserted_tokens.second_factor.alert.successful '|trans  }}
+{{ 'ss.self_asserted_tokens.second_factor.vetting.alert.failed'|trans  }}
 {{ 'ss.self_asserted_tokens.second_factor.vetting.alert.successful'|trans  }}
 {{ 'ss.self_asserted_tokens.second_factor.no_available_recovery_token.alert.failed'|trans  }}
+{{ 'ss.form.recovery_token.error.challenge_not_sent_error_message'|trans  }}
+{{ 'ss.recovery_token.step_up.failed'|trans }}
+{{ 'ss.recovery_token.step_up.no_tokens_available.failed'|trans }}
 
 {# Self-asserted registration - recovery token type translations #}
 {{ 'sms'|trans  }}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/AuthenticationRequestFactory.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/AuthenticationRequestFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens;
+
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\SAML2\AuthnRequest;
+use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
+use Surfnet\StepupBundle\Value\Loa;
+
+class AuthenticationRequestFactory
+{
+    /**
+     * @var ServiceProvider
+     */
+    private $serviceProvider;
+
+    /**
+     * @var IdentityProvider
+     */
+    private $identityProvider;
+
+    public function __construct(
+        ServiceProvider $serviceProvider,
+        IdentityProvider $identityProvider
+    ) {
+        $this->serviceProvider = $serviceProvider;
+        $this->identityProvider = $identityProvider;
+    }
+
+    public function createSecondFactorRequest(string $nameId, Loa $loa): AuthnRequest
+    {
+        $authenticationRequest = AuthnRequestFactory::createNewRequest(
+            $this->serviceProvider,
+            $this->identityProvider
+        );
+
+        $authenticationRequest->setSubject($nameId);
+        $authenticationRequest->setAuthenticationContextClassRef((string) $loa);
+
+        return $authenticationRequest;
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/Dto/ReturnTo.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/Dto/ReturnTo.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\Dto;
+
+class ReturnTo
+{
+    private $route;
+
+    private $parameters;
+
+    public function __construct(string $route, array $parameters)
+    {
+        $this->route = $route;
+        $this->parameters = $parameters;
+    }
+
+    public function getRoute(): string
+    {
+        return $this->route;
+    }
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/RecoveryTokenService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/RecoveryTokenService.php
@@ -24,6 +24,7 @@ use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\VerifiedSecondFactor;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RecoveryTokenService as MiddlewareRecoveryTokenService;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\SafeStoreAuthenticationCommand;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\Dto\ReturnTo;
 
 class RecoveryTokenService
 {
@@ -42,13 +43,20 @@ class RecoveryTokenService
      */
     private $logger;
 
+    /**
+     * @var RecoveryTokenState
+     */
+    private $stateStore;
+
     public function __construct(
         MiddlewareRecoveryTokenService $recoveryTokenService,
         SafeStoreService $safeStoreService,
+        RecoveryTokenState $recoveryTokenState,
         LoggerInterface $logger
     ) {
         $this->recoveryTokenService = $recoveryTokenService;
         $this->safeStoreService = $safeStoreService;
+        $this->stateStore = $recoveryTokenState;
         $this->logger = $logger;
     }
 
@@ -114,5 +122,55 @@ class RecoveryTokenService
             }
         }
         return $tokens;
+    }
+
+    public function startStepUpRequest(string $requestId): void
+    {
+        $this->stateStore->startStepUpRequest($requestId);
+    }
+
+    public function hasStepUpRequest(): bool
+    {
+        return $this->stateStore->hasStepUpRequest();
+    }
+
+    public function getStepUpRequest(): string
+    {
+        return $this->stateStore->getStepUpRequest();
+    }
+
+    public function deleteStepUpRequest(): void
+    {
+        $this->stateStore->deleteStepUpRequest();
+    }
+
+    public function wasStepUpGiven(): bool
+    {
+        return $this->stateStore->getStepUpGiven();
+    }
+
+    public function stepUpGiven(): void
+    {
+        $this->stateStore->setStepUpGiven(true);
+    }
+
+    public function setReturnTo(string $route, array $parameters = [])
+    {
+        $this->stateStore->setReturnTo($route, $parameters);
+    }
+
+    public function returnTo(): ReturnTo
+    {
+        return $this->stateStore->returnTo();
+    }
+
+    public function resetReturnTo() :void
+    {
+        $this->stateStore->resetReturnTo();
+    }
+
+    public function resetStepUpGiven()
+    {
+        $this->stateStore->resetStepUpGiven();
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/RecoveryTokenState.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/RecoveryTokenState.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens;
+
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\Dto\ReturnTo;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * State manager for Recovery Tokens
+ *
+ * There are several scenarios where we keep recovery token state. They are:
+ *
+ * 1. Store the SAML AuthNRequest request id to match the step up authentication
+ *    with the corresponding SAML Response
+ * 2. Keep track of whether a Recovery Token is being registered during SF token
+ *    registration or not.
+ * 3. Remember the route where to return to after giving step up
+ * 4. Store the fact if step up was given for a given Recovery Token action.
+ */
+class RecoveryTokenState
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    public const RECOVERY_TOKEN_STEP_UP_REQUEST_ID_IDENTIFIER = 'recovery_token_step_up_request_id';
+
+    private const RECOVERY_TOKEN_STEP_UP_GIVEN_IDENTIFIER = 'recovery_token_step_up_given';
+
+    private const RECOVERY_TOKEN_REGISTRATION_IDENTIFIER = 'recovery_token_created_during_registration';
+
+    private const RECOVERY_TOKEN_RETURN_TO_IDENTIFIER = 'recovery_token_return_to';
+
+    public const RECOVERY_TOKEN_RETURN_TO_DELETE = 'ss_recovery_token_delete';
+
+    public const RECOVERY_TOKEN_RETURN_TO_CREATE_SAFE_STORE = 'ss_recovery_token_safe_store';
+
+    public const RECOVERY_TOKEN_RETURN_TO_CREATE_SMS = 'ss_recovery_token_sms';
+
+
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    public function tokenCreatedDuringSecondFactorRegistration(): void
+    {
+        $this->session->set(self::RECOVERY_TOKEN_REGISTRATION_IDENTIFIER, true);
+    }
+
+    public function wasRecoveryTokenCreatedDuringSecondFactorRegistration(): bool
+    {
+        if ($this->session->has(self::RECOVERY_TOKEN_REGISTRATION_IDENTIFIER)) {
+            return $this->session->get(self::RECOVERY_TOKEN_REGISTRATION_IDENTIFIER);
+        }
+        return false;
+    }
+
+    public function forgetSafeStoreTokenCreatedDuringSecondFactorRegistration(): void
+    {
+        $this->session->remove(self::RECOVERY_TOKEN_REGISTRATION_IDENTIFIER);
+    }
+
+    public function startStepUpRequest(string $requestId): void
+    {
+        $this->session->set(self::RECOVERY_TOKEN_STEP_UP_REQUEST_ID_IDENTIFIER, $requestId);
+    }
+
+    public function hasStepUpRequest(): bool
+    {
+        return $this->session->has(self::RECOVERY_TOKEN_STEP_UP_REQUEST_ID_IDENTIFIER);
+    }
+
+    public function getStepUpRequest(): string
+    {
+        return $this->session->get(self::RECOVERY_TOKEN_STEP_UP_REQUEST_ID_IDENTIFIER);
+    }
+
+    public function deleteStepUpRequest(): void
+    {
+        $this->session->remove(self::RECOVERY_TOKEN_STEP_UP_REQUEST_ID_IDENTIFIER);
+    }
+
+    public function setReturnTo(string $route, array $parameters)
+    {
+        $this->session->set(self::RECOVERY_TOKEN_RETURN_TO_IDENTIFIER, new ReturnTo($route, $parameters));
+    }
+
+    public function returnTo(): ReturnTo
+    {
+        return $this->session->get(self::RECOVERY_TOKEN_RETURN_TO_IDENTIFIER);
+    }
+
+    public function resetReturnTo()
+    {
+        $this->session->remove(self::RECOVERY_TOKEN_RETURN_TO_IDENTIFIER);
+    }
+
+    public function getStepUpGiven(): bool
+    {
+        if (!$this->session->has(self::RECOVERY_TOKEN_STEP_UP_GIVEN_IDENTIFIER)) {
+            return false;
+        }
+        return $this->session->get(self::RECOVERY_TOKEN_STEP_UP_GIVEN_IDENTIFIER);
+    }
+
+    public function setStepUpGiven(bool $given)
+    {
+        $this->session->set(self::RECOVERY_TOKEN_STEP_UP_GIVEN_IDENTIFIER, $given);
+    }
+
+    public function resetStepUpGiven()
+    {
+        $this->session->remove(self::RECOVERY_TOKEN_STEP_UP_GIVEN_IDENTIFIER);
+    }
+}

--- a/translations/messages.en_GB.xliff
+++ b/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-06-22T14:33:47Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2022-06-28T10:24:49Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -42,12 +42,12 @@
       <trans-unit id="e59d5dbfb886036d6a99e85bf857442d4ea4009c" resname="safe-store">
         <source>safe-store</source>
         <target>Safe store</target>
-        <jms:reference-file line="60">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="64">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="83b04e2653917150804a1a71da678664e3e509b5" resname="sms">
         <source>sms</source>
         <target>SMS</target>
-        <jms:reference-file line="59">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="63">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b4adb3d9176c2fbdf293bee1b7dda2c6fb56c67c" resname="ss.flash.error_while_switching_locale">
         <source>ss.flash.error_while_switching_locale</source>
@@ -78,6 +78,11 @@
         <source>ss.form.recovery_token.delete.success</source>
         <target state="translated">Your recovery token was removed successfully</target>
         <jms:reference-file line="51">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="e426ad1c2c11cf5702e4808054059e41d7756524" resname="ss.form.recovery_token.error.challenge_not_sent_error_message">
+        <source>ss.form.recovery_token.error.challenge_not_sent_error_message</source>
+        <target state="translated">Sending of the SMS verification code failed. Please try again.</target>
+        <jms:reference-file line="58">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1056c8b78526c39c46b53c03b442af8e07e83ca6" resname="ss.form.recovery_token.error.error_message">
         <source>ss.form.recovery_token.error.error_message</source>
@@ -194,6 +199,16 @@
         <source>ss.recovery_token.sms.send_challenge_title</source>
         <target state="translated">Register an SMS recovery token</target>
         <jms:reference-file line="3">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/self_asserted_tokens/create_sms.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="fb1af9d7b1a3a1ae5faa7e626ef5946cb2d9a315" resname="ss.recovery_token.step_up.failed">
+        <source>ss.recovery_token.step_up.failed</source>
+        <target state="translated">Verification with your token failed. Please try again</target>
+        <jms:reference-file line="59">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="d66a9a79cff9eab1025ad228d31555e0721722c4" resname="ss.recovery_token.step_up.no_tokens_available.failed">
+        <source>ss.recovery_token.step_up.no_tokens_available.failed</source>
+        <target state="translated">Unable to create or remove a recovery token without possession of a second factor token. Please visit the service desk to remove the recovery token or vet a new second factor token.</target>
+        <jms:reference-file line="60">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="231069934a847862c6128f2dca767b9a577aed18" resname="ss.recovery_token_list.header.recovery_token_identifier">
         <source>ss.recovery_token_list.header.recovery_token_identifier</source>
@@ -452,7 +467,7 @@ For all devices with a USB port.</target>
       </trans-unit>
       <trans-unit id="3c5270965cff002b6b94695f1a75f8d42b9cf915" resname="ss.registration.self_asserted.choose_recovery_token.title">
         <source>ss.registration.self_asserted.choose_recovery_token.title</source>
-        <target state="new">ss.registration.self_asserted.choose_recovery_token.title</target>
+        <target state="translated">SMS [Recovery Token]</target>
         <jms:reference-file line="3">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/self_asserted_tokens/select_available_recovery_token.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f8916d206cdd9e68de226df4e66e3bb4b7b48733" resname="ss.registration.self_asserted.new_recovery_token.title">
@@ -767,12 +782,17 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="03881b38b73aa0c36816dfeb6ce493f01bae69cd" resname="ss.self_asserted_tokens.second_factor.no_available_recovery_token.alert.failed">
         <source>ss.self_asserted_tokens.second_factor.no_available_recovery_token.alert.failed</source>
         <target>Unable to activate the token with your [recovery-token]. For example, you are not allowed to activate an SMS token with an SMS [recovery token]</target>
-        <jms:reference-file line="56">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="57">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="d3653739e7a9767a2a614acb62d85eac2421d7af" resname="ss.self_asserted_tokens.second_factor.vetting.alert.failed">
+        <source>ss.self_asserted_tokens.second_factor.vetting.alert.failed</source>
+        <target state="translated">Token activation failed, please try again</target>
+        <jms:reference-file line="55">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="da675d9cfce3bea01d6ff884c6941a4cb00de0ed" resname="ss.self_asserted_tokens.second_factor.vetting.alert.successful">
         <source>ss.self_asserted_tokens.second_factor.vetting.alert.successful</source>
         <target state="translated">Your token was activated</target>
-        <jms:reference-file line="55">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="56">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="35dcfa9d6b292923d95e80d966959f1ceb95a513" resname="ss.self_vet.second_factor.alert.failed">
         <source>ss.self_vet.second_factor.alert.failed</source>

--- a/translations/messages.nl_NL.xliff
+++ b/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-06-22T14:33:43Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2022-06-28T10:24:46Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -42,12 +42,12 @@
       <trans-unit id="e59d5dbfb886036d6a99e85bf857442d4ea4009c" resname="safe-store">
         <source>safe-store</source>
         <target>Safe store</target>
-        <jms:reference-file line="60">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="64">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="83b04e2653917150804a1a71da678664e3e509b5" resname="sms">
         <source>sms</source>
         <target>SMS</target>
-        <jms:reference-file line="59">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="63">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b4adb3d9176c2fbdf293bee1b7dda2c6fb56c67c" resname="ss.flash.error_while_switching_locale">
         <source>ss.flash.error_while_switching_locale</source>
@@ -78,6 +78,11 @@
         <source>ss.form.recovery_token.delete.success</source>
         <target state="translated">Je [recovery token] is succesvol verwijderd</target>
         <jms:reference-file line="51">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="e426ad1c2c11cf5702e4808054059e41d7756524" resname="ss.form.recovery_token.error.challenge_not_sent_error_message">
+        <source>ss.form.recovery_token.error.challenge_not_sent_error_message</source>
+        <target state="translated">Het verzenden van de SMS verificatiecode is mislukt, probeer opnieuw</target>
+        <jms:reference-file line="58">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1056c8b78526c39c46b53c03b442af8e07e83ca6" resname="ss.form.recovery_token.error.error_message">
         <source>ss.form.recovery_token.error.error_message</source>
@@ -186,7 +191,7 @@
       </trans-unit>
       <trans-unit id="879c12224efa2d6f5da55a898e8f828dcbd9fea3" resname="ss.recovery_token.sms.prove_possession_title">
         <source>ss.recovery_token.sms.prove_possession_title</source>
-        <target state="new">ss.recovery_token.sms.prove_possession_title</target>
+        <target state="translated">SMS [Recovery token]</target>
         <jms:reference-file line="3">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/self_asserted_tokens/registration_sms_prove_possession.html.twig</jms:reference-file>
         <jms:reference-file line="3">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/self_asserted_tokens/sms_prove_possession.html.twig</jms:reference-file>
       </trans-unit>
@@ -194,6 +199,16 @@
         <source>ss.recovery_token.sms.send_challenge_title</source>
         <target state="translated">Registreer een SMS [Recovery token]</target>
         <jms:reference-file line="3">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/self_asserted_tokens/create_sms.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="fb1af9d7b1a3a1ae5faa7e626ef5946cb2d9a315" resname="ss.recovery_token.step_up.failed">
+        <source>ss.recovery_token.step_up.failed</source>
+        <target state="translated">Verificatie met je token is mislukt</target>
+        <jms:reference-file line="59">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="d66a9a79cff9eab1025ad228d31555e0721722c4" resname="ss.recovery_token.step_up.no_tokens_available.failed">
+        <source>ss.recovery_token.step_up.no_tokens_available.failed</source>
+        <target state="translated">Het is niet mogelijk om een [recovery token] toe te voegen of te verwijderen zonder een token. Bezoek de service desk om het [recovery token] te verwijderen, of registreer een nieuw token.</target>
+        <jms:reference-file line="60">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="231069934a847862c6128f2dca767b9a577aed18" resname="ss.recovery_token_list.header.recovery_token_identifier">
         <source>ss.recovery_token_list.header.recovery_token_identifier</source>
@@ -765,12 +780,17 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="03881b38b73aa0c36816dfeb6ce493f01bae69cd" resname="ss.self_asserted_tokens.second_factor.no_available_recovery_token.alert.failed">
         <source>ss.self_asserted_tokens.second_factor.no_available_recovery_token.alert.failed</source>
         <target>Je hebt geen geschikt [recovery-token] om je token mee te activeren. Je mag bijvoorbeeld met een SMS [recovery-token] niet een SMS token activeren.</target>
-        <jms:reference-file line="56">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="57">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="d3653739e7a9767a2a614acb62d85eac2421d7af" resname="ss.self_asserted_tokens.second_factor.vetting.alert.failed">
+        <source>ss.self_asserted_tokens.second_factor.vetting.alert.failed</source>
+        <target state="translated">Het activeren van je token is mislukt, probeer het opnieuw</target>
+        <jms:reference-file line="55">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="da675d9cfce3bea01d6ff884c6941a4cb00de0ed" resname="ss.self_asserted_tokens.second_factor.vetting.alert.successful">
         <source>ss.self_asserted_tokens.second_factor.vetting.alert.successful</source>
         <target state="translated">Je token is geactiveerd</target>
-        <jms:reference-file line="55">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
+        <jms:reference-file line="56">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="35dcfa9d6b292923d95e80d966959f1ceb95a513" resname="ss.self_vet.second_factor.alert.failed">
         <source>ss.self_vet.second_factor.alert.failed</source>

--- a/translations/validators.en_GB.xliff
+++ b/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-06-22T14:33:47Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2022-06-28T10:24:49Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/translations/validators.nl_NL.xliff
+++ b/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-06-22T14:33:43Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2022-06-28T10:24:46Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>


### PR DESCRIPTION
1. In preparation, the SAT controller was cleaned up by segregating the dedicated RT actions from the registration related actions
2. The 'test' authentication consume assertion endpoint was re-re-used to also serve self-asserted recovery token step up authentications. I considered creating a new SFO SP for this. But that would get complex really soon. The step up bundle does not support multiple ACS locations either. So this solution seemed to fit best.
 