### PR TITLE
Display the Institutional vetting type hint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,4 @@ branches:
     - master
     - develop
     - feature/self-asserted-tokens
+    - /^feature/sat-.*$/

--- a/composer.lock
+++ b/composer.lock
@@ -2988,12 +2988,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
-                "reference": "abd471fe7dc491627ebe3a98ef8d56cdb903a63a"
+                "reference": "224e496da9b61997cddd035f4706e6ba89bf0474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/abd471fe7dc491627ebe3a98ef8d56cdb903a63a",
-                "reference": "abd471fe7dc491627ebe3a98ef8d56cdb903a63a",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/224e496da9b61997cddd035f4706e6ba89bf0474",
+                "reference": "224e496da9b61997cddd035f4706e6ba89bf0474",
                 "shasum": ""
             },
             "require": {
@@ -3045,7 +3045,7 @@
                 "source": "https://github.com/OpenConext/Stepup-Middleware-clientbundle/tree/feature/self-asserted-tokens",
                 "issues": "https://github.com/OpenConext/Stepup-Middleware-clientbundle/issues"
             },
-            "time": "2022-07-19T08:57:16+00:00"
+            "time": "2022-07-26T09:50:54+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
@@ -95,13 +95,16 @@ class RegistrationController extends Controller
      * @Template
      * @param string $secondFactorId
      */
-    public function displayVettingTypesAction($secondFactorId)
+    public function displayVettingTypesAction(Request $request, $secondFactorId)
     {
         /**
          * @var VettingTypeService
          */
         $vettingTypeService = $this->get(VettingTypeService::class);
         $vettingTypeCollection = $vettingTypeService->vettingTypes($this->getIdentity(), $secondFactorId);
+        $institution = $this->getIdentity()->institution;
+        $currentLocale = $request->getLocale();
+
         if (!$vettingTypeCollection->allowSelfVetting() && !$vettingTypeCollection->allowSelfAssertedTokens()) {
             $this->get('logger')
                 ->notice(
@@ -116,6 +119,8 @@ class RegistrationController extends Controller
             'allowSelfVetting' => $vettingTypeCollection->allowSelfVetting(),
             'allowSelfAssertedTokens' => $vettingTypeCollection->allowSelfAssertedTokens(),
             'highlightOnPremise' => $vettingTypeCollection->isPreferred(VettingTypeInterface::ON_PREMISE),
+            'hasVettingTypeHint' => true,
+            'vettingTypeHint' => $vettingTypeService->vettingTypeHint($institution, $currentLocale),
             'highlightSelfAssertedTokens' => $vettingTypeCollection->isPreferred(
                 VettingTypeInterface::SELF_ASSERTED_TOKENS
             ),

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RegistrationController.php
@@ -102,8 +102,6 @@ class RegistrationController extends Controller
          */
         $vettingTypeService = $this->get(VettingTypeService::class);
         $vettingTypeCollection = $vettingTypeService->vettingTypes($this->getIdentity(), $secondFactorId);
-        $institution = $this->getIdentity()->institution;
-        $currentLocale = $request->getLocale();
 
         if (!$vettingTypeCollection->allowSelfVetting() && !$vettingTypeCollection->allowSelfAssertedTokens()) {
             $this->get('logger')
@@ -115,12 +113,17 @@ class RegistrationController extends Controller
                 ['secondFactorId' => $secondFactorId]
             );
         }
+
+        $institution = $this->getIdentity()->institution;
+        $currentLocale = $request->getLocale();
+        $vettingTypeHint = $vettingTypeService->vettingTypeHint($institution, $currentLocale);
+
         return [
             'allowSelfVetting' => $vettingTypeCollection->allowSelfVetting(),
             'allowSelfAssertedTokens' => $vettingTypeCollection->allowSelfAssertedTokens(),
             'highlightOnPremise' => $vettingTypeCollection->isPreferred(VettingTypeInterface::ON_PREMISE),
-            'hasVettingTypeHint' => true,
-            'vettingTypeHint' => $vettingTypeService->vettingTypeHint($institution, $currentLocale),
+            'hasVettingTypeHint' => !is_null($vettingTypeHint),
+            'vettingTypeHint' => $vettingTypeHint,
             'highlightSelfAssertedTokens' => $vettingTypeCollection->isPreferred(
                 VettingTypeInterface::SELF_ASSERTED_TOKENS
             ),

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -144,6 +144,7 @@ services:
             - '@self_service.service.self_vet_marshaller'
             - '@self_service.service.self_asserted_tokens_marshaller'
             - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\ActivationFlowService'
+            - '@Surfnet\StepupMiddlewareClientBundle\Identity\Service\VettingTypeHintService'
             - '@logger'
 
     Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenService:

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig
@@ -15,12 +15,21 @@
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-
     <div class="row">
         <div class="col-xs-12 col-md-12">
             <p>{{ 'ss.registration.vetting_type.description.vetting'|trans }}</p>
         </div>
     </div>
+
+
+    {% if hasVettingTypeHint %}
+        <div class="row">
+            <div class="col-xs-12 col-md-12">
+                <p class="alert alert-info" role="alert">{{ vettingTypeHint|escape }}</p>
+            </div>
+        </div>
+    {% endif %}
+
     <div class="row remote-vetting">
         {% if allowSelfVetting %}
           <div class="col-xs-12 col-md-3">

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/AuthorizationService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/AuthorizationService.php
@@ -37,4 +37,9 @@ class AuthorizationService
     {
         return $this->authorizationService->assertRegistrationOfSelfAssertedTokensIsAllowed($identity);
     }
+
+    public function mayRegisterRecoveryTokens(Identity $identity): bool
+    {
+        return $this->authorizationService->assertRegistrationOfRecoveryTokensIsAllowed($identity);
+    }
 }

--- a/translations/messages.en_GB.xliff
+++ b/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-06-28T10:24:49Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2022-07-27T14:58:28Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -406,17 +406,17 @@
       <trans-unit id="7c01f0c80cf83ed8fda6f899a31058df8f20baa2" resname="ss.registration.selector.on-premise.alt">
         <source>ss.registration.selector.on-premise.alt</source>
         <target>Servicedesk</target>
-        <jms:reference-file line="60">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="69">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="978b459c168d75e1cc1cacb9577fcfd6b48ce40c" resname="ss.registration.selector.self_asserted_tokens.alt">
         <source>ss.registration.selector.self_asserted_tokens.alt</source>
         <target>Self asserted token</target>
-        <jms:reference-file line="45">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="54">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f2fccc6470be3068080fd903fcd1cdda9a7cf357" resname="ss.registration.selector.self_vet.alt">
         <source>ss.registration.selector.self_vet.alt</source>
         <target>Activated token</target>
-        <jms:reference-file line="29">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6348b54419006fd2ee31e33581af254358acd8e8" resname="ss.registration.selector.sms.alt">
         <source>ss.registration.selector.sms.alt</source>
@@ -546,37 +546,37 @@ For all devices with a USB port.</target>
       <trans-unit id="6afeab6302e7089dd152da59ff6167355993e1fd" resname="ss.registration.vetting_type.button.ra_vetting">
         <source>ss.registration.vetting_type.button.ra_vetting</source>
         <target>Continue</target>
-        <jms:reference-file line="66">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="75">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="69dea38e752d5face42561fc82e2ace24744ac3e" resname="ss.registration.vetting_type.button.self_asserted_tokens">
         <source>ss.registration.vetting_type.button.self_asserted_tokens</source>
         <target>Continue</target>
-        <jms:reference-file line="51">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="60">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="20dea31f0328ab5116f6104ad7b0c614439fb7f5" resname="ss.registration.vetting_type.button.self_vet">
         <source>ss.registration.vetting_type.button.self_vet</source>
         <target>Continue</target>
-        <jms:reference-file line="35">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="44">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="36f60e5402c0f9f29d5167f5448cf08e9b309176" resname="ss.registration.vetting_type.description.ra_vetting">
         <source>ss.registration.vetting_type.description.ra_vetting</source>
         <target>Activate your token at your intitution's servicedesk.</target>
-        <jms:reference-file line="63">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="72">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="28a12bced010e17743538e9eebaab14200e961f0" resname="ss.registration.vetting_type.description.self_asserted_tokens">
         <source>ss.registration.vetting_type.description.self_asserted_tokens</source>
         <target>Activate this token without an ID check. The token might not be usable for every application.</target>
-        <jms:reference-file line="48">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="57">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d72f763c2ed38cada18ea9e0a56b08f89178a454" resname="ss.registration.vetting_type.description.self_vet">
         <source>ss.registration.vetting_type.description.self_vet</source>
         <target>Use your existing token.</target>
-        <jms:reference-file line="32">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="41">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8e8386218b7c03203e839b5e6742d008f84d4f2" resname="ss.registration.vetting_type.description.vetting">
         <source>ss.registration.vetting_type.description.vetting</source>
         <target>You must activate your token. Choose one of these options:</target>
-        <jms:reference-file line="21">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6b0aa1451c1b8e3edaa9a2064a2949108bb818ed" resname="ss.registration.vetting_type.title">
         <source>ss.registration.vetting_type.title</source>
@@ -586,17 +586,17 @@ For all devices with a USB port.</target>
       <trans-unit id="495f21302f01269871f9993f2b8da38bee78fe87" resname="ss.registration.vetting_type.title.ra_vetting">
         <source>ss.registration.vetting_type.title.ra_vetting</source>
         <target>Servicedesk vetting</target>
-        <jms:reference-file line="61">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="70">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1f9c008be46d78bf37a98d1e98d0758aa070015e" resname="ss.registration.vetting_type.title.self_asserted_tokens">
         <source>ss.registration.vetting_type.title.self_asserted_tokens</source>
         <target>Recovery Token</target>
-        <jms:reference-file line="46">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="55">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ed511e112f15e353c9c9122d9db7ec8039a592f6" resname="ss.registration.vetting_type.title.self_vet">
         <source>ss.registration.vetting_type.title.self_vet</source>
         <target>Activated token</target>
-        <jms:reference-file line="30">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="51b48a932a70ae43f768348cb7631f248fffd1b1" resname="ss.registration.yubikey.text.connect_yubikey_to_pc">
         <source>ss.registration.yubikey.text.connect_yubikey_to_pc</source>
@@ -621,7 +621,7 @@ For all devices with a USB port.</target>
       <trans-unit id="e0c3b599c6452627b605f6481046ccd6a9ccb405" resname="ss.second_factor.button.remote_vet">
         <source>ss.second_factor.button.remote_vet</source>
         <target>Activate</target>
-        <jms:reference-file line="74">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="82">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4ee3b496dd41dd774e53cd591a5105c5555ac9f9" resname="ss.second_factor.list.button.register_recovery_token">
         <source>ss.second_factor.list.button.register_recovery_token</source>
@@ -681,7 +681,7 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
         <source>ss.second_factor.revoke.button.revoke</source>
         <target>Remove</target>
         <jms:reference-file line="26">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/crud_list.html.twig</jms:reference-file>
-        <jms:reference-file line="79">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="87">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d18b6bcd8642fedf8e5371cb722efc604e8281" resname="ss.second_factor.revoke.button.test">
         <source>ss.second_factor.revoke.button.test</source>
@@ -736,13 +736,18 @@ An e-mail with your activation code has been sent to the e-mail address %email%.
       <trans-unit id="de7df14a4a009c74319576cad9e6c6e68e89ac0c" resname="ss.second_factor_list.header.expired_explanation">
         <source>ss.second_factor_list.header.expired_explanation</source>
         <target>The token registration period has expired. Please remove your token and restart the registration process.</target>
-        <jms:reference-file line="90">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="98">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1d6751b490158de0a89683522c6ba1a8b957875c" resname="ss.second_factor_list.header.expired_warning">
         <source>ss.second_factor_list.header.expired_warning</source>
         <target>Expired</target>
-        <jms:reference-file line="65">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
-        <jms:reference-file line="90">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="68">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="98">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="67c27f02624a58b03dc898ecdf1a81ffb8d48d18" resname="ss.second_factor_list.header.loa">
+        <source>ss.second_factor_list.header.loa</source>
+        <target state="translated">Level of assurance</target>
+        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fedd12f3e661692730a3650ef6db64e71c9d8441" resname="ss.second_factor_list.header.second_factor_identifier">
         <source>ss.second_factor_list.header.second_factor_identifier</source>

--- a/translations/messages.nl_NL.xliff
+++ b/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-06-28T10:24:46Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2022-07-27T14:58:24Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -406,17 +406,17 @@
       <trans-unit id="7c01f0c80cf83ed8fda6f899a31058df8f20baa2" resname="ss.registration.selector.on-premise.alt">
         <source>ss.registration.selector.on-premise.alt</source>
         <target>Servicedesk</target>
-        <jms:reference-file line="60">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="69">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="978b459c168d75e1cc1cacb9577fcfd6b48ce40c" resname="ss.registration.selector.self_asserted_tokens.alt">
         <source>ss.registration.selector.self_asserted_tokens.alt</source>
         <target>Zelfgeregeld token</target>
-        <jms:reference-file line="45">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="54">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f2fccc6470be3068080fd903fcd1cdda9a7cf357" resname="ss.registration.selector.self_vet.alt">
         <source>ss.registration.selector.self_vet.alt</source>
         <target>Geactiveerd token</target>
-        <jms:reference-file line="29">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="38">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6348b54419006fd2ee31e33581af254358acd8e8" resname="ss.registration.selector.sms.alt">
         <source>ss.registration.selector.sms.alt</source>
@@ -546,37 +546,37 @@ Geschikt voor alle devices met een USB-poort.</target>
       <trans-unit id="6afeab6302e7089dd152da59ff6167355993e1fd" resname="ss.registration.vetting_type.button.ra_vetting">
         <source>ss.registration.vetting_type.button.ra_vetting</source>
         <target>Verder</target>
-        <jms:reference-file line="66">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="75">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="69dea38e752d5face42561fc82e2ace24744ac3e" resname="ss.registration.vetting_type.button.self_asserted_tokens">
         <source>ss.registration.vetting_type.button.self_asserted_tokens</source>
         <target>Verder</target>
-        <jms:reference-file line="51">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="60">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="20dea31f0328ab5116f6104ad7b0c614439fb7f5" resname="ss.registration.vetting_type.button.self_vet">
         <source>ss.registration.vetting_type.button.self_vet</source>
         <target>Verder</target>
-        <jms:reference-file line="35">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="44">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="36f60e5402c0f9f29d5167f5448cf08e9b309176" resname="ss.registration.vetting_type.description.ra_vetting">
         <source>ss.registration.vetting_type.description.ra_vetting</source>
         <target>Activeer je token bij de servicedesk van je instelling.</target>
-        <jms:reference-file line="63">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="72">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="28a12bced010e17743538e9eebaab14200e961f0" resname="ss.registration.vetting_type.description.self_asserted_tokens">
         <source>ss.registration.vetting_type.description.self_asserted_tokens</source>
         <target>Activeer dit token zonder persoonsbewijs. Het token is mogelijk niet voor iedere applicatie bruikbaar.</target>
-        <jms:reference-file line="48">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="57">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d72f763c2ed38cada18ea9e0a56b08f89178a454" resname="ss.registration.vetting_type.description.self_vet">
         <source>ss.registration.vetting_type.description.self_vet</source>
         <target>Gebruik je bestaand token.</target>
-        <jms:reference-file line="32">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="41">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8e8386218b7c03203e839b5e6742d008f84d4f2" resname="ss.registration.vetting_type.description.vetting">
         <source>ss.registration.vetting_type.description.vetting</source>
         <target>Je moet je token activeren. Kies één van deze opties:</target>
-        <jms:reference-file line="21">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6b0aa1451c1b8e3edaa9a2064a2949108bb818ed" resname="ss.registration.vetting_type.title">
         <source>ss.registration.vetting_type.title</source>
@@ -586,17 +586,17 @@ Geschikt voor alle devices met een USB-poort.</target>
       <trans-unit id="495f21302f01269871f9993f2b8da38bee78fe87" resname="ss.registration.vetting_type.title.ra_vetting">
         <source>ss.registration.vetting_type.title.ra_vetting</source>
         <target>Servicedesk</target>
-        <jms:reference-file line="61">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="70">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1f9c008be46d78bf37a98d1e98d0758aa070015e" resname="ss.registration.vetting_type.title.self_asserted_tokens">
         <source>ss.registration.vetting_type.title.self_asserted_tokens</source>
         <target>Recovery token</target>
-        <jms:reference-file line="46">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="55">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ed511e112f15e353c9c9122d9db7ec8039a592f6" resname="ss.registration.vetting_type.title.self_vet">
         <source>ss.registration.vetting_type.title.self_vet</source>
         <target>Token</target>
-        <jms:reference-file line="30">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="51b48a932a70ae43f768348cb7631f248fffd1b1" resname="ss.registration.yubikey.text.connect_yubikey_to_pc">
         <source>ss.registration.yubikey.text.connect_yubikey_to_pc</source>
@@ -621,7 +621,7 @@ Geschikt voor alle devices met een USB-poort.</target>
       <trans-unit id="e0c3b599c6452627b605f6481046ccd6a9ccb405" resname="ss.second_factor.button.remote_vet">
         <source>ss.second_factor.button.remote_vet</source>
         <target>Activeer</target>
-        <jms:reference-file line="74">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="82">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4ee3b496dd41dd774e53cd591a5105c5555ac9f9" resname="ss.second_factor.list.button.register_recovery_token">
         <source>ss.second_factor.list.button.register_recovery_token</source>
@@ -679,7 +679,7 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
         <source>ss.second_factor.revoke.button.revoke</source>
         <target>Verwijderen</target>
         <jms:reference-file line="26">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/crud_list.html.twig</jms:reference-file>
-        <jms:reference-file line="79">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="87">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d18b6bcd8642fedf8e5371cb722efc604e8281" resname="ss.second_factor.revoke.button.test">
         <source>ss.second_factor.revoke.button.test</source>
@@ -734,13 +734,18 @@ Er is een e-mail met activatiecode gestuurd naar het e-mailadres %email%. Volg d
       <trans-unit id="de7df14a4a009c74319576cad9e6c6e68e89ac0c" resname="ss.second_factor_list.header.expired_explanation">
         <source>ss.second_factor_list.header.expired_explanation</source>
         <target>De uiterste registratiedatum is verlopen. Registreer het token opnieuw door deze te verwijderen en het registratieproces opnieuw te starten.</target>
-        <jms:reference-file line="90">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="98">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1d6751b490158de0a89683522c6ba1a8b957875c" resname="ss.second_factor_list.header.expired_warning">
         <source>ss.second_factor_list.header.expired_warning</source>
         <target>Verlopen</target>
-        <jms:reference-file line="65">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
-        <jms:reference-file line="90">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="68">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+        <jms:reference-file line="98">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="67c27f02624a58b03dc898ecdf1a81ffb8d48d18" resname="ss.second_factor_list.header.loa">
+        <source>ss.second_factor_list.header.loa</source>
+        <target state="translated">Betrouwbaarheid</target>
+        <jms:reference-file line="53">/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/second_factor/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fedd12f3e661692730a3650ef6db64e71c9d8441" resname="ss.second_factor_list.header.second_factor_identifier">
         <source>ss.second_factor_list.header.second_factor_identifier</source>

--- a/translations/validators.en_GB.xliff
+++ b/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-06-28T10:24:49Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2022-07-27T14:58:28Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -365,6 +365,14 @@
       <trans-unit id="e79eeb815d177674e3eb22c7b0f58c27154f55ec" resname="middleware_client.dto.vetted_second_factor.type.must_not_be_blank">
         <source>middleware_client.dto.vetted_second_factor.type.must_not_be_blank</source>
         <target state="new">middleware_client.dto.vetted_second_factor.type.must_not_be_blank</target>
+      </trans-unit>
+      <trans-unit id="206b3baa3328ecbba2acf5ffd656d07e1550eb33" resname="middleware_client.dto.vetted_second_factor.veting_type.must_be_string">
+        <source>middleware_client.dto.vetted_second_factor.veting_type.must_be_string</source>
+        <target state="new">middleware_client.dto.vetted_second_factor.veting_type.must_be_string</target>
+      </trans-unit>
+      <trans-unit id="79ec021e919bdadfc0ab50569cfbb52676ce1502" resname="middleware_client.dto.vetted_second_factor.vetting_typ.must_not_be_blank">
+        <source>middleware_client.dto.vetted_second_factor.vetting_typ.must_not_be_blank</source>
+        <target state="new">middleware_client.dto.vetted_second_factor.vetting_typ.must_not_be_blank</target>
       </trans-unit>
       <trans-unit id="d23ad73b357db56cd8de5ead80613a379e7fb7f9" resname="ss.send_sms_challenge_command.recipient.may_not_be_empty">
         <source>ss.send_sms_challenge_command.recipient.may_not_be_empty</source>

--- a/translations/validators.nl_NL.xliff
+++ b/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-06-28T10:24:46Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2022-07-27T14:58:24Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -365,6 +365,14 @@
       <trans-unit id="e79eeb815d177674e3eb22c7b0f58c27154f55ec" resname="middleware_client.dto.vetted_second_factor.type.must_not_be_blank">
         <source>middleware_client.dto.vetted_second_factor.type.must_not_be_blank</source>
         <target state="new">middleware_client.dto.vetted_second_factor.type.must_not_be_blank</target>
+      </trans-unit>
+      <trans-unit id="206b3baa3328ecbba2acf5ffd656d07e1550eb33" resname="middleware_client.dto.vetted_second_factor.veting_type.must_be_string">
+        <source>middleware_client.dto.vetted_second_factor.veting_type.must_be_string</source>
+        <target state="new">middleware_client.dto.vetted_second_factor.veting_type.must_be_string</target>
+      </trans-unit>
+      <trans-unit id="79ec021e919bdadfc0ab50569cfbb52676ce1502" resname="middleware_client.dto.vetted_second_factor.vetting_typ.must_not_be_blank">
+        <source>middleware_client.dto.vetted_second_factor.vetting_typ.must_not_be_blank</source>
+        <target state="new">middleware_client.dto.vetted_second_factor.vetting_typ.must_not_be_blank</target>
       </trans-unit>
       <trans-unit id="d23ad73b357db56cd8de5ead80613a379e7fb7f9" resname="ss.send_sms_challenge_command.recipient.may_not_be_empty">
         <source>ss.send_sms_challenge_command.recipient.may_not_be_empty</source>


### PR DESCRIPTION
If available, show the translated vetting type hint for the institution of the identity logged in to the self service.

The message is displayed on the choose vetting type page (if available). If only one vetting type is present. For example, when only desk vetting is possible. The text is not displayed.

[f8f3dd1](https://github.com/OpenConext/Stepup-SelfService/pull/268/commits/f8f3dd16869f984362a9b096753258e60b831992) was added during acceptance testing of the new feature. It stood out that a user with a token vetted on premise, still was allowed to add recovery tokens. And that should not be the case!

/boyscout