### PR TITLE
Allow RT revocation without SF token possession

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "yargs-parser": ">=18.1.2"
     },
     "resolutions": {
-        "glob-parent": ">=6.0.1"
+        "glob-parent": ">=6.0.1",
+        "terser": ">=5.14.2"
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenController.php
@@ -279,17 +279,6 @@ class RecoveryTokenController extends Controller
      */
     public function deleteAction(string $recoveryTokenId): Response
     {
-        if (!$this->recoveryTokenService->wasStepUpGiven()) {
-            $this->recoveryTokenService->setReturnTo(
-                RecoveryTokenState::RECOVERY_TOKEN_RETURN_TO_DELETE,
-                ['recoveryTokenId' => $recoveryTokenId]
-            );
-            return $this->forward(
-                "Surfnet\StepupSelfService\SelfServiceBundle\Controller\RecoveryTokenController::stepUpAction"
-            );
-        }
-        $this->recoveryTokenService->resetReturnTo();
-        $this->recoveryTokenService->resetStepUpGiven();
         $this->assertRecoveryTokenInPossession($recoveryTokenId, $this->getIdentity());
         try {
             $recoveryToken = $this->recoveryTokenService->getRecoveryToken($recoveryTokenId);

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfAssertedTokensController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfAssertedTokensController.php
@@ -20,7 +20,6 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Controller;
 
 use Psr\Log\LoggerInterface;
 use Surfnet\StepupBundle\Service\LoaResolutionService;
-use Surfnet\StepupBundle\Service\SmsRecoveryTokenService;
 use Surfnet\StepupBundle\Value\PhoneNumber\InternationalPhoneNumber;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\PromiseSafeStorePossessionCommand;
 use Surfnet\StepupSelfService\SelfServiceBundle\Command\SafeStoreAuthenticationCommand;
@@ -34,6 +33,7 @@ use Surfnet\StepupSelfService\SelfServiceBundle\Service\SecondFactorService;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\AuthenticationRequestFactory;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenService;
 use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\SafeStoreService;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsRecoveryTokenService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/RecoveryTokenState.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/RecoveryTokenState.php
@@ -48,8 +48,6 @@ class RecoveryTokenState
 
     private const RECOVERY_TOKEN_RETURN_TO_IDENTIFIER = 'recovery_token_return_to';
 
-    public const RECOVERY_TOKEN_RETURN_TO_DELETE = 'ss_recovery_token_delete';
-
     public const RECOVERY_TOKEN_RETURN_TO_CREATE_SAFE_STORE = 'ss_recovery_token_safe_store';
 
     public const RECOVERY_TOKEN_RETURN_TO_CREATE_SMS = 'ss_recovery_token_sms';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5796,7 +5796,7 @@ terser-webpack-plugin@^5.1.1, terser-webpack-plugin@^5.1.3:
     serialize-javascript "^6.0.0"
     terser "^5.7.2"
 
-terser@^5.7.2:
+terser@>=5.14.2, terser@^5.7.2:
   version "5.14.2"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
   integrity sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==


### PR DESCRIPTION
A recovery token can always be revoked, no step up authentication is required to do so.

The change to `SelfAssertedTokensController` is a boyscout rule fixup. The stepup bundle service was used directly, where use of the SelfService service was required. This was caused by a merge-conflict some time ago..

See: https://www.pivotaltracker.com/story/show/182842669