### PR TITLE
Add toggles to disable recovery token types

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7629,16 +7629,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.15.1",
+            "version": "v2.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3b7cedb2f736899a7dbd0ba3d6da335a015f5cc4"
+                "reference": "ab402673db8746cb3a4c46f3869d6253699f614a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3b7cedb2f736899a7dbd0ba3d6da335a015f5cc4",
-                "reference": "3b7cedb2f736899a7dbd0ba3d6da335a015f5cc4",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ab402673db8746cb3a4c46f3869d6253699f614a",
+                "reference": "ab402673db8746cb3a4c46f3869d6253699f614a",
                 "shasum": ""
             },
             "require": {
@@ -7693,7 +7693,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v2.15.1"
+                "source": "https://github.com/twigphp/Twig/tree/v2.15.3"
             },
             "funding": [
                 {
@@ -7705,7 +7705,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-17T05:46:24+00:00"
+            "time": "2022-09-28T08:40:08+00:00"
         },
         {
             "name": "ua-parser/uap-php",

--- a/config/legacy/parameters.yaml.dist
+++ b/config/legacy/parameters.yaml.dist
@@ -64,3 +64,9 @@ parameters:
     preferred_activation_flow_name: activate
     preferred_activation_flow_options: [ra, self]
 
+    # Self-asserted tokens: enable/disable recovery methods
+    #
+    # One of the two options should be enabled to have a fully functioning
+    # Self-asserted token registration process.
+    recovery_method_sms_enabled: true
+    recovery_method_safe_store_code_enabled: true

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SecondFactorController.php
@@ -61,7 +61,7 @@ class SecondFactorController extends Controller
         $authorizationService = $this->get(AuthorizationService::class);
         $recoveryTokensAllowed = $authorizationService->mayRegisterRecoveryTokens($identity);
         $selfAssertedTokenRegistration = $options->allowSelfAssertedTokens === true && $recoveryTokensAllowed;
-
+        $hasRemainingTokenTypes = count($recoveryTokenService->getRemainingTokenTypes($identity)) > 0;
         $recoveryTokens = [];
         if ($selfAssertedTokenRegistration && $recoveryTokensAllowed) {
             $recoveryTokens = $recoveryTokenService->getRecoveryTokensForIdentity($identity);
@@ -80,6 +80,7 @@ class SecondFactorController extends Controller
             'expirationHelper' => $expirationHelper,
             'selfAssertedTokenRegistration' => $selfAssertedTokenRegistration,
             'recoveryTokens' => $recoveryTokens,
+            'hasRemainingRecoveryTokens' => $hasRemainingTokenTypes,
         ];
     }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -147,11 +147,17 @@ services:
             - '@Surfnet\StepupMiddlewareClientBundle\Identity\Service\VettingTypeHintService'
             - '@logger'
 
+    Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenConfig:
+        arguments:
+            - '%recovery_method_sms_enabled%'
+            - '%recovery_method_safe_store_code_enabled%'
+
     Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenService:
         arguments:
             - '@Surfnet\StepupMiddlewareClientBundle\Identity\Service\RecoveryTokenService'
             - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\SafeStoreService'
             - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenState'
+            - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenConfig'
             - '@logger'
 
     Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\SafeStoreState:

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/crud_list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/crud_list.html.twig
@@ -38,13 +38,14 @@
         <p>{{ 'ss.second_factor.list.text.no_recovery_tokens'|trans }}</p>
     {% endif %}
 
+    {% if hasRemainingRecoveryTokens %}
     <p>
         <a href="{{ path('ss_recovery_token_display_types') }}"
            class="btn btn-primary pull-right">
             {{ 'ss.second_factor.list.button.register_recovery_token'|trans }}
         </a>
     </p>
-
+    {% endif %}
     <p>&nbsp;</p>
     <p>&nbsp;</p>
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/Exception/RecoveryTokenConfigurationException.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/Exception/RecoveryTokenConfigurationException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\Exception;
+
+use Surfnet\StepupSelfService\SelfServiceBundle\Exception\RuntimeException;
+
+class RecoveryTokenConfigurationException extends RuntimeException
+{
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/RecoveryTokenConfig.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SelfAssertedTokens/RecoveryTokenConfig.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens;
+
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\Exception\RecoveryTokenConfigurationException;
+
+class RecoveryTokenConfig
+{
+    /**
+     * @var bool
+     */
+    private $smsEnabled;
+
+    /**
+     * @var bool
+     */
+    private $safeStoreCodeEnabled;
+
+    public function __construct(bool $smsEnabled, bool $safeStoreCodeEnabled)
+    {
+        if ($smsEnabled === false && $safeStoreCodeEnabled === false) {
+            throw new RecoveryTokenConfigurationException('The SMS or safe-store code recovery token must be enabled');
+        }
+        $this->smsEnabled = $smsEnabled;
+        $this->safeStoreCodeEnabled = $safeStoreCodeEnabled;
+    }
+
+    public function isSmsDisabled(): bool
+    {
+        return !$this->smsEnabled;
+    }
+
+    public function isSafeStoreCodeDisabled(): bool
+    {
+        return !$this->safeStoreCodeEnabled;
+    }
+}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/SelfAssertedTokens/RecoveryTokenConfigTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/SelfAssertedTokens/RecoveryTokenConfigTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Tests\Service\SelfAssertedTokens;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\Exception\RecoveryTokenConfigurationException;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenConfig;
+
+class RecoveryTokenConfigTest extends TestCase
+{
+    public function test_both_recovery_token_methods_can_be_enabled()
+    {
+        $config = new RecoveryTokenConfig(true, true);
+        self::assertFalse($config->isSafeStoreCodeDisabled());
+        self::assertFalse($config->isSmsDisabled());
+    }
+
+    public function test_only_sms_can_be_enabled()
+    {
+        $config = new RecoveryTokenConfig(true, false);
+        self::assertTrue($config->isSafeStoreCodeDisabled());
+        self::assertFalse($config->isSmsDisabled());
+    }
+
+    public function test_only_safe_store_can_be_enabled()
+    {
+        $config = new RecoveryTokenConfig(false, true);
+        self::assertFalse($config->isSafeStoreCodeDisabled());
+        self::assertTrue($config->isSmsDisabled());
+    }
+
+    public function test_not_allowed_to_disable_both()
+    {
+        self::expectException(RecoveryTokenConfigurationException::class);
+        self::expectExceptionMessage('The SMS or safe-store code recovery token must be enabled');
+        new RecoveryTokenConfig(false, false);
+    }
+}


### PR DESCRIPTION
SMS or safe store recovery token types can be enabled and disabled. But never can both be disabled.

See https://www.pivotaltracker.com/story/show/183636781