### PR TITLE
Repair return type inconsistency in recovery token trait

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenControllerTrait.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenControllerTrait.php
@@ -73,7 +73,8 @@ trait RecoveryTokenControllerTrait
 
             if ($otpRequestsRemaining === 0) {
                 $this->addFlash('error', 'ss.prove_phone_possession.challenge_request_limit_reached');
-                return array_merge(['form' => $form->createView()], $viewVariables);
+                $parameters = array_merge(['form' => $form->createView()], $viewVariables);
+                return $this->render($templateName, $parameters);
             }
 
             if ($this->smsService->sendChallenge($command)) {


### PR DESCRIPTION
The handleSmsChallenge can return a Response when the OTP challenge request limit is reached. Before this fix, the trait would return an array response. Resulting in this error in the logs:

`php.CRITICAL: Uncaught Error: Return value of Surfnet\StepupSelfService\SelfServiceBundle\Controller\SelfAssertedTokensController::handleSmsChallenge() must be an instance of Symfony\Component\HttpFoundation\Response, array returned {"exception":"[object] (TypeError(code: 0): Return value of Surfnet\\StepupSelfService\\SelfServiceBundle\\Controller\\SelfAssertedTokensController::handleSmsChallenge() must be an instance of Symfony\\Component\\HttpFoundation\\Response, array returned at /src/Stepup-SelfService/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenControllerTrait.php:76)`

To fix that issue, the array return statement is updated to also return a Response object. Simply using the Twig Template that was requested for this response.

No formal bug ticket was created for this bug