### PR TITLE
SMS prove possession route not found

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/SmsController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/SmsController.php
@@ -46,7 +46,11 @@ class SmsController extends Controller
         $service = $this->get('surfnet_stepup_self_service_self_service.service.sms_second_factor');
         $otpRequestsRemaining = $service->getOtpRequestsRemainingCount(SmsSecondFactorServiceInterface::REGISTRATION_SECOND_FACTOR_ID);
         $maximumOtpRequests = $service->getMaximumOtpRequestsCount();
-        $viewVariables = ['otpRequestsRemaining' => $otpRequestsRemaining, 'maximumOtpRequests' => $maximumOtpRequests];
+        $viewVariables = [
+            'otpRequestsRemaining' => $otpRequestsRemaining,
+            'maximumOtpRequests' => $maximumOtpRequests,
+            'verifyEmail' => $this->emailVerificationIsRequired(),
+        ];
 
         if ($form->isSubmitted() && $form->isValid()) {
             $command->identity = $identity->id;
@@ -67,7 +71,6 @@ class SmsController extends Controller
         return array_merge(
             [
                 'form' => $form->createView(),
-                'verifyEmail' => $this->emailVerificationIsRequired(),
             ],
             $viewVariables
         );

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
@@ -130,6 +130,11 @@ ss_registration_sms_send_challenge:
     methods:  [GET,POST]
     defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:Registration/Sms:sendChallenge }
 
+ss_registration_sms_prove_possession:
+    path:     /registration/sms/prove-possession
+    methods:  [GET,POST]
+    defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:Registration/Sms:provePossession }
+
 ss_registration_gssf_status_report:
     path:     /registration/gssf/{provider}/status
     methods:  [GET]


### PR DESCRIPTION
The ss_registration_sms_prove_possession might have been skipped by the
SMS RT proof op posession where it was removed. During that action this
route was also removed. But it was still used in the token registration
of an SMS token.

The other commit states that: When the max attempts are expired, the view vars did not include the
verifyEmail property. That was fixed in this boy scout commit.

See: https://www.pivotaltracker.com/story/show/184750138