### PR TITLE
Add autocompte="off" to secret input fields

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/AuthenticateSafeStoreType.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/AuthenticateSafeStoreType.php
@@ -32,7 +32,10 @@ class AuthenticateSafeStoreType extends AbstractType
         $builder->add('secret', PasswordType::class, [
             'label' => 'ss.form.ss_authenticate_safe_store_type.text.secret',
             'required' => true,
-            'attr' => ['autofocus' => true],
+            'attr' => [
+                'autofocus' => true,
+                'autocomplete' => 'off'
+            ],
         ]);
         $builder->add('verifySecret', SubmitType::class, [
             'label' => 'ss.form.ss_authenticate_safe_store_type.button.continue',

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/VerifySmsChallengeType.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Form/Type/VerifySmsChallengeType.php
@@ -33,7 +33,10 @@ class VerifySmsChallengeType extends AbstractType
         $builder->add('challenge', TextType::class, [
             'label' => 'ss.form.ss_verify_sms_challenge.text.challenge',
             'required' => true,
-            'attr' => ['autofocus' => true],
+            'attr' => [
+                'autofocus' => true,
+                'autocomplete' => 'off',
+            ],
             'label_attr' => ['class' => 'pull-right'],
         ]);
         $builder->add('resendChallenge', AnchorType::class, [


### PR DESCRIPTION
This was done for the safe-store recovery token authentication form and the verify sms challenge forms.

See: https://www.pivotaltracker.com/story/show/185006156