### PR TITLE
Only show RT button and text when appropriate

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/crud_list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/crud_list.html.twig
@@ -1,4 +1,4 @@
-{% if selfAssertedTokenRegistration %}
+{% if (selfAssertedTokenRegistration and recoveryTokens is not empty) or (selfAssertedTokenRegistration and vettedSecondFactors.elements is not empty) %}
     <hr>
     <h2>{{ 'ss.recovery_token_list.title'|trans }}</h2>
 
@@ -40,7 +40,7 @@
         <p>{{ 'ss.second_factor.list.text.no_recovery_tokens'|trans }}</p>
     {% endif %}
 
-    {% if hasRemainingRecoveryTokens %}
+        {% if hasRemainingRecoveryTokens and vettedSecondFactors.elements is not empty %}
     <p>
         <a href="{{ path('ss_recovery_token_display_types') }}"
            class="btn btn-primary pull-right">


### PR DESCRIPTION
When the user is in possession of a vetted token and a recovery token, then display the RT text and add RT button (if one is available for addition)