### PR TITLE
Set correct route for SMS resend button

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenControllerTrait.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/RecoveryTokenControllerTrait.php
@@ -121,7 +121,14 @@ trait RecoveryTokenControllerTrait
 
         $command = new VerifySmsRecoveryTokenChallengeCommand();
         $command->identity = $identity->id;
-        $command->resendRoute = 'ss_recovery_token_sms';
+
+        $command->resendRoute = 'ss_registration_recovery_token_sms';
+        $command->resendRouteParameters = ['secondFactorId' => $secondFactorId, 'recoveryTokenId' => null];
+
+        if (!$secondFactorId) {
+            $command->resendRoute = 'ss_recovery_token_sms';
+            $command->resendRouteParameters = [];
+        }
 
         $form = $this->createForm(VerifySmsChallengeType::class, $command)->handleRequest($request);
 


### PR DESCRIPTION
During registration, the wrong route was visited for the sms resend form. That resulted in the form being submitted unsuccessfully. By testing if the secondfactor id is set (this is never the case when adding a second RT from the token overview page) we can set the correct route and params for both scenarios.