### PR TITLE
Remove unnecessary enctype from form

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/generic_second_factor.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/partial/generic_second_factor.html.twig
@@ -25,7 +25,7 @@
             }}
         </p>
         <p>
-            <form method="post" enctype="text/plain" accept-charset="UTF-8" action="{{ url }}">
+            <form method="post" accept-charset="UTF-8" action="{{ url }}">
                 <button type="submit" class="btn btn-primary">
                     {{ secondFactor.getButtonUse() }}
                 </button>


### PR DESCRIPTION
OWASP core ruleset will complain about this, because the use of `text/plain` in conjunction with `method=post` is effectively useless (form values will never become available in the $_POST global).

The form functions just fine without it.