### PR TITLE
Ensure display of Authn errors

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Exception/MissingRequiredAttributeException.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Exception/MissingRequiredAttributeException.php
@@ -20,8 +20,6 @@ declare(strict_types = 1);
 
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Exception;
 
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
-
-final class MissingRequiredAttributeException extends AuthenticationException
+final class MissingRequiredAttributeException extends RuntimeException
 {
 }


### PR DESCRIPTION
In SF 6, the new exception handler does not show the exception message in the exception handler. Rather, these errors are handled at another point (authn listeners).

Also see: https://stackoverflow.com/questions/40174266/not-all-exceptions-catched-within-the-error-handler