### PR TITLE
Simplify exception logical condition, showing the attribute missing error message once again

### DIFF
--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -302,37 +302,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/EntryPointController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Instanceof between Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException and Surfnet\\\\StepupSelfService\\\\SelfServiceBundle\\\\Exception\\\\MissingRequiredAttributeException will always evaluate to false\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Surfnet\\\\StepupSelfService\\\\SelfServiceBundle\\\\Controller\\\\ExceptionController\\:\\:getPageTitleAndDescription\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Result of && is always false\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Undefined variable\\: \\$description$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Undefined variable\\: \\$title$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Variable \\$description in isset\\(\\) is never defined\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Variable \\$title in isset\\(\\) is never defined\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php',
 ];

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/ExceptionController.php
@@ -28,7 +28,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 use Surfnet\StepupBundle\Controller\ExceptionController as BaseExceptionController;
 use Surfnet\StepupSelfService\SelfServiceBundle\Exception\MissingRequiredAttributeException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final class ExceptionController extends BaseExceptionController
 {
@@ -39,7 +38,7 @@ final class ExceptionController extends BaseExceptionController
     {
         $translator = $this->getTranslator();
 
-        if ($exception instanceof HttpException && $exception instanceof MissingRequiredAttributeException) {
+        if ($exception instanceof MissingRequiredAttributeException) {
             $title = $translator->trans('stepup.error.missing_required_attribute.title');
             $description = $exception->getMessage();
         }


### PR DESCRIPTION
When rendering the custom exception page, we test if the MissingRequiredAttributeException. But it also had to be a HTTP exception. That was never the case (also before #313).

By removing the first part of the statement, the error message is displayed correctly once again.

See: https://github.com/OpenConext/Stepup-SelfService/pull/315