### PR TITLE
Set correct SelfVet ACS route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
+# 5.0.4
+- Correct a route name with a missing namespace part (self vetting acs) #320
+
 # 5.0.3
 - Repair exeption screens
 - Fix flash messages
+
+# 5.0.2
+- Read flash messages from the correct bag #314 
+- Simplify exception logical condition, showing the attribute missing error message once again #315
+- Multiple updates of Composer/Node dependencies 
 
 # 5.0.1
 - Removed a piece of dead authentication code #312

--- a/ci/qa/phpstan-baseline.php
+++ b/ci/qa/phpstan-baseline.php
@@ -547,11 +547,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfVet/SelfVetConsumeController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, Surfnet\\\\StepupSelfService\\\\SelfServiceBundle\\\\Value\\\\SelfVetRequestId given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfVet/SelfVetConsumeController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property Surfnet\\\\StepupSelfService\\\\SelfServiceBundle\\\\Command\\\\SelfVetCommand\\:\\:\\$authoringLoa \\(string\\) does not accept string\\|null\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfVet/SelfVetConsumeController.php',
@@ -885,11 +880,6 @@ $ignoreErrors[] = [
 	'message' => '#^Method Surfnet\\\\StepupSelfService\\\\SelfServiceBundle\\\\Service\\\\RaLocationService\\:\\:listRaLocationsFor\\(\\) has parameter \\$institution with no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Service/RaLocationService.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Access to an undefined property Surfnet\\\\StepupMiddlewareClientBundle\\\\Identity\\\\Command\\\\SelfVetSecondFactorCommand\\:\\:\\$authoringSecondFactorLoa\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getElements\\(\\) on Surfnet\\\\StepupMiddlewareClientBundle\\\\Identity\\\\Dto\\\\UnverifiedSecondFactorCollection\\|Surfnet\\\\StepupMiddlewareClientBundle\\\\Identity\\\\Dto\\\\VerifiedSecondFactorCollection\\|Surfnet\\\\StepupMiddlewareClientBundle\\\\Identity\\\\Dto\\\\VettedSecondFactorCollection\\|null\\.$#',

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SamlController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SamlController.php
@@ -126,7 +126,7 @@ class SamlController extends AbstractController
             $selfVetRequestId = $session->get(SelfVetController::SELF_VET_SESSION_ID);
             $secondFactorId = $selfVetRequestId->vettingSecondFactorId();
             return $this->forward(
-                'Surfnet\StepupSelfService\SelfServiceBundle\Controller\SelfVetController::consumeSelfVetAssertion',
+                'Surfnet\StepupSelfService\SelfServiceBundle\Controller\SelfVet\SelfVetConsumeController::consumeSelfVetAssertion',
                 ['secondFactorId' => $secondFactorId],
             );
         }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfVet/SelfVetConsumeController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfVet/SelfVetConsumeController.php
@@ -41,7 +41,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) - Controllers are prone to higher coupling. This one is no exception
- * TODO: Split up into smaller controllers
  */
 class SelfVetConsumeController extends AbstractController
 {

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfVet/SelfVetConsumeController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/SelfVet/SelfVetConsumeController.php
@@ -97,7 +97,7 @@ class SelfVetConsumeController extends AbstractController
                 $samlLogger->error(
                     sprintf(
                         'Expected a response to the request with ID "%s", but the SAMLResponse was a response to a different request',
-                        $initiatedRequestId
+                        $initiatedRequestId->requestId()
                     )
                 );
                 throw new AuthenticationException('Unexpected InResponseTo in SAMLResponse');

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yaml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yaml
@@ -30,9 +30,20 @@ services:
             - '@surfnet_saml.http.redirect_binding'
             - '@surfnet_saml.http.post_binding'
             - '@surfnet_saml.hosted.service_provider'
-            - '@self_service.second_factor_test_idp'
+            - '@surfnet_saml.remote.idp'
             - '@surfnet_saml.logger'
             - '@logger'
+
+    Surfnet\StepupSelfService\SelfServiceBundle\Controller\SelfVet\SelfVetConsumeController:
+        arguments:
+            - "@logger"
+            - "@surfnet_stepup_self_service_self_service.service.second_factor"
+            - "@self_service.service.self_vet_marshaller"
+            - "@surfnet_saml.hosted.service_provider"
+            - '@surfnet_saml.remote.idp'
+            - "@surfnet_saml.http.post_binding"
+            - "@surfnet_saml.logger"
+            - "@request_stack"
 
     surfnet_stepup_self_service_self_service.service.command:
         class: Surfnet\StepupSelfService\SelfServiceBundle\Service\CommandService

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yaml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yaml
@@ -19,22 +19,6 @@ services:
 
     Surfnet\StepupSelfService\SelfServiceBundle\Service\ControllerCheckerService:
 
-    #    Surfnet\StepupSelfService\SelfServiceBundle\Controller\SelfVetController:
-#        arguments:
-#            - "@self_service.test_second_factor_authentication_request_factory"
-#            - "@surfnet_stepup_self_service_self_service.service.second_factor"
-#            - "@surfnet_stepup.service.second_factor_type"
-#            - "@self_service.service.self_vet_marshaller"
-#            - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\AuthorizationService'
-#            - "@surfnet_saml.hosted.service_provider"
-#            - "@self_service.second_factor_test_idp"
-#            - "@surfnet_saml.http.redirect_binding"
-#            - "@surfnet_saml.http.post_binding"
-#            - "@surfnet_stepup.service.loa_resolution"
-#            - "@surfnet_saml.logger"
-#            - "@request_stack"
-#            - "@logger"
-
     Surfnet\StepupSelfService\SelfServiceBundle\Controller\RecoveryTokenController:
         arguments:
             - '@Surfnet\StepupSelfService\SelfServiceBundle\Service\SelfAssertedTokens\RecoveryTokenService'

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SecondFactorService.php
@@ -84,7 +84,7 @@ class SecondFactorService
         $apiCommand->secondFactorId = $command->secondFactor->secondFactorIdentifier;
         $apiCommand->secondFactorType = $command->secondFactor->type;
         $apiCommand->authorityId = $command->identity->id;
-        $apiCommand->authoringSecondFactorLoa = $command->authoringLoa;
+        $apiCommand->authoringSecondFactorIdentifier = $command->authoringLoa;
 
         $result = $this->commandService->execute($apiCommand);
         return $result->isSuccessful();


### PR DESCRIPTION
The additional SelfVet namespace was not yet reflrected in the route (forward) name.

This was the only occurence where the SelfVetController is called by name. There should not be other wrong calls in the project.

See: https://www.pivotaltracker.com/story/show/187412638