### PR TITLE
Remove framework.session.*liftime settings

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -19,8 +19,6 @@ framework:
         cookie_httponly: true
         cookie_secure: true
         cookie_samesite: none
-        cookie_lifetime: '%session_max_absolute_lifetime%'
-        gc_maxlifetime: '%session_max_relative_lifetime%'
 
     fragments: false
     error_controller: Surfnet\StepupSelfService\SelfServiceBundle\Controller\ExceptionController::show


### PR DESCRIPTION
They make the app cookie into a session cookie with a given lifetime. We want them to be a non persistent cookie

See: https://www.pivotaltracker.com/story/show/187651480