### PR TITLE
Use entitlement when no query parameter is set

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/ActivationFlowService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/ActivationFlowService.php
@@ -83,6 +83,11 @@ class ActivationFlowService
             ];
         }
 
+        if ($requestedActivationPreference instanceof ActivationFlowPreferenceNotExpressed && count($availableActivationPreferences) === 1) {
+            $this->logger->info('Only one activation flow allowed');
+            return $availableActivationPreferences[0];
+        }
+
         if (in_array($requestedActivationPreference, $availableActivationPreferences)) {
             $this->logger->info('Found allowed activation flow');
             return $requestedActivationPreference;
@@ -148,6 +153,7 @@ class ActivationFlowService
 
         $activationFlows = [];
         $attributes = $token->getAttributes();
+
         if (array_key_exists($this->attributeName, $attributes)) {
             $this->logger->debug('Found entitlement saml attributes');
             if (in_array($this->attributes['ra'], $attributes[$this->attributeName])) {

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/ActivationFlowServiceTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/ActivationFlowServiceTest.php
@@ -185,6 +185,21 @@ class ActivationFlowServiceTest extends MockeryTestCase
         $this->assertEquals($preference, new ActivationFlowPreferenceNotExpressed());
     }
 
+
+    public function testSamlAttributeMustUseTheAllowTheOnlyAttributeWhenNoQueryParameterIsSet(): void {
+        $this->mockToken(['urn:mace:surf.nl:surfsecureid:activation:ra']);
+        $this->stateHandler->shouldReceive('getRequestedActivationFlowPreference')
+            ->andReturn(new ActivationFlowPreferenceNotExpressed());
+
+        $this->logger->shouldReceive('info')->with('Analysing saml entitlement attributes for allowed activation flows')->once();
+        $this->logger->shouldReceive('debug')->with('Found entitlement saml attributes')->once();
+        $this->logger->shouldReceive('info')->with('Only one activation flow allowed')->once();
+
+        $preference = $this->service->getPreference();
+        $this->assertEquals($preference, ActivationFlowPreference::createRa());
+    }
+
+
     private function mockToken(array $entitlements = null) {
         $attributes = $entitlements != null ? ['urn:mace:dir:attribute-def:eduPersonEntitlement' => $entitlements] : [];
         $this->tokenStorage->shouldReceive('getToken')


### PR DESCRIPTION
This change will use the only activation flow that's allowed through the entitlement SAML attribute when no preferred activation flow is set with a query parameter.

This was encountered while enhancing the Behat tests with the ability to add SAML-attributes.