### PR TITLE
Update image from default (Trusty) to Ubuntu 22.04.5 LTS Jammy (Jellyfish)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,6 @@
 build:
+    # Use Ubuntu 22.04.5 LTS (Jammy Jellyfish)
+    image: default-jammy
     environment:
         php:
             version: 8.2


### PR DESCRIPTION
The node version used requires a newer glib, update to latest Ubuntu image that is offered by Scrutenizer.